### PR TITLE
Minimalistic start endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Executor = class {
+    /**
+     * Starts a k8s build
+     * @method start
+     * @param  {Object}   config   A configuration object
+     * @param  {Function} callback Callback function
+     */
+    start(config, callback) {
+        process.nextTick(callback);
+    }
+};
+
+module.exports = Executor;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,17 @@
 'use strict';
-const assert = require('chai').assert;
 
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+describe('start', () => {
+    let Executor;
+
+    beforeEach(() => {
+        /* eslint-disable global-require */
+        Executor = require('../index');
+        /* eslint-enable global-require */
+    });
+
+    it('calls back', (done) => {
+        const executor = new Executor();
+
+        executor.start({}, done);
     });
 });


### PR DESCRIPTION
Enable `.start()` endpoint to be usable and useless