### PR TITLE
Create/start job with k8s executor

### DIFF
--- a/config/job.yaml.tim
+++ b/config/job.yaml.tim
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{build_id}}
+  labels:
+    sdbuild: {{build_id}}
+    sdjob: {{job_id}}
+    sdpipeline: {{pipeline_id}}
+spec:
+  completions: 1
+  template:
+    metadata:
+      labels:
+        sdbuild: {{build_id}}
+        sdjob: {{job_id}}
+        sdpipeline: {{pipeline_id}}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: launcher
+        image: screwdrivercd/job-tools:v0.1.0
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "mkdir -p /opt/job-tools && cp -a /opt/screwdriver/* /opt/job-tools && touch /opt/job-tools/loaded"
+        volumeMounts:
+        - mountPath: /opt/job-tools
+          name: screwdriver
+
+      - name: build
+        image: node:4
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "echo -n Fetching build tools.; while ! [ -f /opt/screwdriver/loaded ]; do echo -n .; sleep 1; done; echo; /opt/screwdriver/launch {{git_org}} {{git_repo}} {{git_branch}} {{job_name}}"
+        volumeMounts:
+        - mountPath: /opt/screwdriver
+          name: screwdriver
+        env:
+        - name: GIT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: git-token
+              key: git
+        - name: NPM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: npm-token
+              key: npm
+      volumes:
+        - name: screwdriver
+          emptyDir: {}

--- a/index.js
+++ b/index.js
@@ -1,15 +1,62 @@
 'use strict';
+const Executor = require('screwdriver-executor-base');
+const fs = require('fs');
+const request = require('request');
+const tinytim = require('tinytim');
+const yaml = require('js-yaml');
+const API_KEY = fs.readFileSync('/etc/kubernetes/apikey', 'utf-8');
+const SCM_URL_REGEX = /^git@([^:]+):([^\/]+)\/(.+?)\.git(#.+)?$/;
+const GIT_ORG = 2;
+const GIT_REPO = 3;
+const GIT_BRANCH = 4;
+const jobsUrl = 'https://kubernetes/apis/batch/v1/namespaces/default/jobs';
 
-const Executor = class {
+class K8sExecutor extends Executor {
     /**
      * Starts a k8s build
      * @method start
-     * @param  {Object}   config   A configuration object
+     * @param  {Object}   config            A configuration object
+     * @param  {Object}   config.buildId    ID for the build
+     * @param  {Object}   config.jobId      ID for the job
+     * @param  {Object}   config.pipelineId ID for the pipeline
+     * @param  {Object}   config.container  Container for the build to run in
+     * @param  {Object}   config.scmUrl     Scm URL to use in the build
      * @param  {Function} callback Callback function
      */
     start(config, callback) {
-        process.nextTick(callback);
-    }
-};
+        const scmMatch = SCM_URL_REGEX.exec(config.scmUrl);
+        const jobTemplate = tinytim.renderFile('./config/job.yaml.tim', {
+            git_org: scmMatch[GIT_ORG],
+            git_repo: scmMatch[GIT_REPO],
+            git_branch: (scmMatch[GIT_BRANCH] || '#master').slice(1),
+            job_name: 'main',
+            build_id: config.buildId,
+            job_id: config.jobId,
+            pipeline_id: config.pipelineId
+        });
 
-module.exports = Executor;
+        const options = {
+            json: yaml.safeLoad(jobTemplate),
+            headers: {
+                Authorization: `Bearer ${API_KEY}`
+            },
+            strictSSL: false
+        };
+
+        request.post(jobsUrl, options, (err, resp, body) => {
+            if (err) {
+                return callback(err);
+            }
+
+            if (resp.statusCode !== 201) {
+                const msg = `Failed to create job: ${JSON.stringify(body)}`;
+
+                return callback(new Error(msg));
+            }
+
+            return callback(null);
+        });
+    }
+}
+
+module.exports = K8sExecutor;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-k8s",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Kubernetes Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,14 @@
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",
-    "jenkins-mocha": "^2.6.0"
+    "jenkins-mocha": "^2.6.0",
+    "mockery": "^1.7.0",
+    "sinon": "^1.17.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "js-yaml": "^3.6.1",
+    "request": "^2.72.0",
+    "screwdriver-executor-base": "0.0.2",
+    "tinytim": "^0.1.1"
+  }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,17 +1,174 @@
 'use strict';
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const mockery = require('mockery');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+const TEST_TIM_YAML = `
+metadata:
+  name: {{build_id}}
+  job: {{job_id}}
+  pipeline: {{pipeline_id}}
+command:
+- "/opt/screwdriver/launch {{git_org}} {{git_repo}} {{git_branch}} {{job_name}}"
+`;
 
 describe('start', () => {
     let Executor;
+    let requestMock;
+    let fsMock;
+    let executor;
+    const testScmUrl = 'git@github.com:screwdriver-cd/hashr.git';
+    const testBuildId = 'build_ad11234tag41fda';
+    const testJobId = 'job_ad11234tag41fda';
+    const testPipelineId = 'pipeline_ad11234tag41fda';
+    const fakeResponse = {
+        statusCode: 201,
+        body: {
+            success: true
+        }
+    };
+    const jobsUrl = 'https://kubernetes/apis/batch/v1/namespaces/default/jobs';
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
 
     beforeEach(() => {
+        requestMock = {
+            post: sinon.stub()
+        };
+        fsMock = {
+            readFileSync: sinon.stub()
+        };
+
+        requestMock.post.yieldsAsync(null, fakeResponse, fakeResponse.body);
+        fsMock.readFileSync.withArgs('/etc/kubernetes/apikey').returns('api_key');
+        fsMock.readFileSync.withArgs('./config/job.yaml.tim').returns(TEST_TIM_YAML);
+
+        mockery.registerMock('fs', fsMock);
+        mockery.registerMock('request', requestMock);
+
         /* eslint-disable global-require */
         Executor = require('../index');
         /* eslint-enable global-require */
+
+        executor = new Executor();
     });
 
-    it('calls back', (done) => {
-        const executor = new Executor();
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
 
-        executor.start({}, done);
+    after(() => {
+        mockery.disable();
+    });
+
+    it('extends base class', () => {
+        assert.isFunction(executor.stop);
+        assert.isFunction(executor.start);
+    });
+
+    describe('successful requests', () => {
+        it('with scmUrl containing branch', (done) => {
+            const postConfig = {
+                json: {
+                    metadata: {
+                        name: testBuildId,
+                        job: testJobId,
+                        pipeline: testPipelineId
+                    },
+                    command: ['/opt/screwdriver/launch screwdriver-cd hashr addSD main']
+                },
+                headers: {
+                    Authorization: 'Bearer api_key'
+                },
+                strictSSL: false
+            };
+
+            executor.start({
+                scmUrl: 'git@github.com:screwdriver-cd/hashr.git#addSD',
+                buildId: testBuildId,
+                jobId: testJobId,
+                pipelineId: testPipelineId
+            }, (err) => {
+                assert.isNull(err);
+                assert.calledWith(requestMock.post, jobsUrl, postConfig);
+                done();
+            });
+        });
+
+        it('with scmUrl without branch', (done) => {
+            const postConfig = {
+                json: {
+                    metadata: {
+                        name: testBuildId,
+                        job: testJobId,
+                        pipeline: testPipelineId
+                    },
+                    command: ['/opt/screwdriver/launch screwdriver-cd hashr master main']
+                },
+                headers: {
+                    Authorization: 'Bearer api_key'
+                },
+                strictSSL: false
+            };
+
+            executor.start({
+                scmUrl: testScmUrl,
+                buildId: testBuildId,
+                jobId: testJobId,
+                pipelineId: testPipelineId
+            }, (err) => {
+                assert.isNull(err);
+                assert.calledWith(requestMock.post, jobsUrl, postConfig);
+                done();
+            });
+        });
+    });
+
+    it('returns error when request responds with error', (done) => {
+        const error = new Error('lol');
+
+        requestMock.post.yieldsAsync(error);
+
+        executor.start({
+            scmUrl: testScmUrl,
+            buildId: testBuildId,
+            jobId: testJobId,
+            pipelineId: testPipelineId
+        }, (err) => {
+            assert.deepEqual(err, error);
+            done();
+        });
+    });
+
+    it('returns body when request responds with error in response', (done) => {
+        const returnResponse = {
+            statusCode: 500,
+            body: {
+                statusCode: 500,
+                message: 'lol'
+            }
+        };
+        const returnMessage = `Failed to create job: ${JSON.stringify(returnResponse.body)}`;
+
+        requestMock.post.yieldsAsync(null, returnResponse, returnResponse.body);
+
+        executor.start({
+            scmUrl: testScmUrl,
+            buildId: testBuildId,
+            jobId: testJobId,
+            pipelineId: testPipelineId
+        }, (err, response) => {
+            assert.notOk(response);
+            assert.equal(err.message, returnMessage);
+            done();
+        });
     });
 });


### PR DESCRIPTION
This PR makes a request to the jobs API in k8s based on the configuration passed into the start function

The function:
1. Parses the scmUrl and extracts the org/repo/branch
2. Uses tinytim to pass those extracted values when creating the job

We are hardcoding the jobName to 'main' right now and will need to have that value passed to the start function 