### PR TITLE
Add function to stream logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,24 +5,26 @@ const path = require('path');
 const request = require('request');
 const tinytim = require('tinytim');
 const yaml = require('js-yaml');
+const hoek = require('hoek');
 const API_KEY = fs.readFileSync('/etc/kubernetes/apikey/token', 'utf-8');
 const SCM_URL_REGEX = /^git@([^:]+):([^\/]+)\/(.+?)\.git(#.+)?$/;
 const GIT_ORG = 2;
 const GIT_REPO = 3;
 const GIT_BRANCH = 4;
 const jobsUrl = 'https://kubernetes/apis/batch/v1/namespaces/default/jobs';
+const podsUrl = 'https://kubernetes/apis/v1/namespaces/default/pods';
 
 class K8sExecutor extends Executor {
     /**
      * Starts a k8s build
      * @method start
      * @param  {Object}   config            A configuration object
-     * @param  {Object}   config.buildId    ID for the build
-     * @param  {Object}   config.jobId      ID for the job
-     * @param  {Object}   config.pipelineId ID for the pipeline
-     * @param  {Object}   config.container  Container for the build to run in
-     * @param  {Object}   config.scmUrl     Scm URL to use in the build
-     * @param  {Function} callback Callback function
+     * @param  {String}   config.buildId    ID for the build
+     * @param  {String}   config.jobId      ID for the job
+     * @param  {String}   config.pipelineId ID for the pipeline
+     * @param  {String}   config.container  Container for the build to run in
+     * @param  {String}   config.scmUrl     Scm URL to use in the build
+     * @param  {Function} callback          Callback function
      */
     start(config, callback) {
         const scmMatch = SCM_URL_REGEX.exec(config.scmUrl);
@@ -56,6 +58,38 @@ class K8sExecutor extends Executor {
             }
 
             return callback(null);
+        });
+    }
+
+    /**
+    * Streams logs
+    * @method stream
+    * @param  {Object}   config            A configuration object
+    * @param  {String}   config.buildId    ID for the build
+    * @param  {Response} response          Response object to stream logs
+    */
+    stream(config, response) {
+        const pod = `${podsUrl}?labelSelector=sdbuild=${config.buildId}`;
+        const options = {
+            headers: {
+                Authorization: `Bearer ${API_KEY}`
+            },
+            json: true,
+            strictSSL: false
+        };
+
+        request.get(pod, options, (err, resp, body) => {
+            if (err) {
+                return response(new Error(`Error getting pod with sdbuild=${config.buildId}`));
+            }
+            const podName = hoek.reach(body, 'items.0.metadata.name');
+
+            if (!podName) {
+                return response(new Error('Error getting pod name'));
+            }
+            const logUrl = `${podsUrl}/${podName}/log?container=build&follow=true&pretty=true`;
+
+            return request.get(logUrl).pipe(response);
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
+    "hoek": "^4.0.1",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",
-    "screwdriver-executor-base": "0.0.2",
+    "screwdriver-executor-base": "0.0.4",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,10 +14,11 @@ command:
 - "/opt/screwdriver/launch {{git_org}} {{git_repo}} {{git_branch}} {{job_name}}"
 `;
 
-describe('start', () => {
+describe('index', () => {
     let Executor;
     let requestMock;
     let fsMock;
+    let pipeMock;
     let executor;
     const testScmUrl = 'git@github.com:screwdriver-cd/hashr.git';
     const testBuildId = 'build_ad11234tag41fda';
@@ -30,6 +31,7 @@ describe('start', () => {
         }
     };
     const jobsUrl = 'https://kubernetes/apis/batch/v1/namespaces/default/jobs';
+    const podsUrl = 'https://kubernetes/apis/v1/namespaces/default/pods';
 
     before(() => {
         mockery.enable({
@@ -40,15 +42,21 @@ describe('start', () => {
 
     beforeEach(() => {
         requestMock = {
-            post: sinon.stub()
+            post: sinon.stub(),
+            get: sinon.stub()
         };
+
+        pipeMock = {
+            pipe: sinon.stub()
+        };
+
         fsMock = {
             readFileSync: sinon.stub()
         };
 
-        requestMock.post.yieldsAsync(null, fakeResponse, fakeResponse.body);
         fsMock.readFileSync.withArgs('/etc/kubernetes/apikey/token').returns('api_key');
-        fsMock.readFileSync.withArgs(sinon.match(/config\/job.yaml.tim/)).returns(TEST_TIM_YAML);
+        fsMock.readFileSync.withArgs(sinon.match(/config\/job.yaml.tim/))
+        .returns(TEST_TIM_YAML);
 
         mockery.registerMock('fs', fsMock);
         mockery.registerMock('request', requestMock);
@@ -74,50 +82,73 @@ describe('start', () => {
         assert.isFunction(executor.start);
     });
 
-    describe('successful requests', () => {
-        it('with scmUrl containing branch', (done) => {
-            const postConfig = {
-                json: {
-                    metadata: {
-                        name: testBuildId,
-                        job: testJobId,
-                        pipeline: testPipelineId
-                    },
-                    command: ['/opt/screwdriver/launch screwdriver-cd hashr addSD main']
-                },
-                headers: {
-                    Authorization: 'Bearer api_key'
-                },
-                strictSSL: false
-            };
+    describe('start', () => {
+        beforeEach(() => {
+            requestMock.post.yieldsAsync(null, fakeResponse, fakeResponse.body);
+        });
 
-            executor.start({
-                scmUrl: 'git@github.com:screwdriver-cd/hashr.git#addSD',
-                buildId: testBuildId,
-                jobId: testJobId,
-                pipelineId: testPipelineId
-            }, (err) => {
-                assert.isNull(err);
-                assert.calledWith(requestMock.post, jobsUrl, postConfig);
-                done();
+        describe('successful requests', () => {
+            it('with scmUrl containing branch', (done) => {
+                const postConfig = {
+                    json: {
+                        metadata: {
+                            name: testBuildId,
+                            job: testJobId,
+                            pipeline: testPipelineId
+                        },
+                        command: ['/opt/screwdriver/launch screwdriver-cd hashr addSD main']
+                    },
+                    headers: {
+                        Authorization: 'Bearer api_key'
+                    },
+                    strictSSL: false
+                };
+
+                executor.start({
+                    scmUrl: 'git@github.com:screwdriver-cd/hashr.git#addSD',
+                    buildId: testBuildId,
+                    jobId: testJobId,
+                    pipelineId: testPipelineId
+                }, (err) => {
+                    assert.isNull(err);
+                    assert.calledWith(requestMock.post, jobsUrl, postConfig);
+                    done();
+                });
+            });
+
+            it('with scmUrl without branch', (done) => {
+                const postConfig = {
+                    json: {
+                        metadata: {
+                            name: testBuildId,
+                            job: testJobId,
+                            pipeline: testPipelineId
+                        },
+                        command: ['/opt/screwdriver/launch screwdriver-cd hashr master main']
+                    },
+                    headers: {
+                        Authorization: 'Bearer api_key'
+                    },
+                    strictSSL: false
+                };
+
+                executor.start({
+                    scmUrl: testScmUrl,
+                    buildId: testBuildId,
+                    jobId: testJobId,
+                    pipelineId: testPipelineId
+                }, (err) => {
+                    assert.isNull(err);
+                    assert.calledWith(requestMock.post, jobsUrl, postConfig);
+                    done();
+                });
             });
         });
 
-        it('with scmUrl without branch', (done) => {
-            const postConfig = {
-                json: {
-                    metadata: {
-                        name: testBuildId,
-                        job: testJobId,
-                        pipeline: testPipelineId
-                    },
-                    command: ['/opt/screwdriver/launch screwdriver-cd hashr master main']
-                },
-                headers: {
-                    Authorization: 'Bearer api_key'
-                },
-                strictSSL: false
-            };
+        it('returns error when request responds with error', (done) => {
+            const error = new Error('lol');
+
+            requestMock.post.yieldsAsync(error);
 
             executor.start({
                 scmUrl: testScmUrl,
@@ -125,50 +156,103 @@ describe('start', () => {
                 jobId: testJobId,
                 pipelineId: testPipelineId
             }, (err) => {
-                assert.isNull(err);
-                assert.calledWith(requestMock.post, jobsUrl, postConfig);
+                assert.deepEqual(err, error);
+                done();
+            });
+        });
+
+        it('returns body when request responds with error in response', (done) => {
+            const returnResponse = {
+                statusCode: 500,
+                body: {
+                    statusCode: 500,
+                    message: 'lol'
+                }
+            };
+            const returnMessage = `Failed to create job: ${JSON.stringify(returnResponse.body)}`;
+
+            requestMock.post.yieldsAsync(null, returnResponse, returnResponse.body);
+
+            executor.start({
+                scmUrl: testScmUrl,
+                buildId: testBuildId,
+                jobId: testJobId,
+                pipelineId: testPipelineId
+            }, (err, response) => {
+                assert.notOk(response);
+                assert.equal(err.message, returnMessage);
                 done();
             });
         });
     });
 
-    it('returns error when request responds with error', (done) => {
-        const error = new Error('lol');
+    describe('stream', () => {
+        const pod = `${podsUrl}?labelSelector=sdbuild=${testBuildId}`;
+        const logUrl = `${podsUrl}/mypod/log?container=build&follow=true&pretty=true`;
 
-        requestMock.post.yieldsAsync(error);
+        it('reply with error when it fails to get pod', (done) => {
+            const error = new Error('lol');
 
-        executor.start({
-            scmUrl: testScmUrl,
-            buildId: testBuildId,
-            jobId: testJobId,
-            pipelineId: testPipelineId
-        }, (err) => {
-            assert.deepEqual(err, error);
-            done();
+            requestMock.get.yieldsAsync(error);
+            executor.stream({
+                buildId: testBuildId
+            }, (err) => {
+                assert.isOk(err);
+                assert.notCalled(pipeMock.pipe);
+                done();
+            });
         });
-    });
 
-    it('returns body when request responds with error in response', (done) => {
-        const returnResponse = {
-            statusCode: 500,
-            body: {
-                statusCode: 500,
-                message: 'lol'
-            }
-        };
-        const returnMessage = `Failed to create job: ${JSON.stringify(returnResponse.body)}`;
+        it('reply with error when podname is not found', (done) => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    items: []
+                }
+            };
 
-        requestMock.post.yieldsAsync(null, returnResponse, returnResponse.body);
+            requestMock.get.withArgs(pod).yieldsAsync(null, returnResponse, returnResponse.body);
+            executor.stream({
+                buildId: testBuildId
+            }, (err) => {
+                assert.isOk(err);
+                assert.notCalled(pipeMock.pipe);
+                done();
+            });
+        });
 
-        executor.start({
-            scmUrl: testScmUrl,
-            buildId: testBuildId,
-            jobId: testJobId,
-            pipelineId: testPipelineId
-        }, (err, response) => {
-            assert.notOk(response);
-            assert.equal(err.message, returnMessage);
-            done();
+        it('stream logs when podname is found', (done) => {
+            const getConfig = {
+                json: true,
+                headers: {
+                    Authorization: 'Bearer api_key'
+                },
+                strictSSL: false
+            };
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    items: [{
+                        metadata: {
+                            name: 'mypod'
+                        }
+                    }]
+                }
+            };
+
+            const returnFunc = (err) => {
+                assert.isNull(err);
+                assert.calledWith(requestMock.get, pod, getConfig);
+                assert.calledWith(pipeMock.pipe, returnFunc);
+                done();
+            };
+
+            requestMock.get.withArgs(pod).yieldsAsync(null, returnResponse, returnResponse.body);
+            requestMock.get.withArgs(logUrl).returns(pipeMock);
+            pipeMock.pipe.yieldsAsync(null);
+            executor.stream({
+                buildId: testBuildId
+            }, returnFunc);
         });
     });
 });


### PR DESCRIPTION
Add stream function to stream logs. This makes a call to get the pod's information based on sdbuild labelSelector. From there, we get the podname and stream the logs of that pod.
This will be used by the plugin-builds https://github.com/screwdriver-cd/plugin-builds/pull/22 
