### PR TITLE
Revert "Add initial resource limits"

### DIFF
--- a/config/job.yaml.tim
+++ b/config/job.yaml.tim
@@ -36,19 +36,6 @@ spec:
         volumeMounts:
         - mountPath: /opt/screwdriver
           name: screwdriver
-        resources:
-          # Upper-bound limits for resources
-          limits:
-            # 4000 milli CPU => 4 CPUs
-            cpu: 4000m
-            # 4096 MB => 4 GB for RAM
-            memory: 4096Mi
-          # Initial resource allocation. Also acts as the lower-bound limit
-          requests:
-            # 2000 milli CPU => 2 CPUs
-            cpu: 2000m
-            # 4096 MB => 4 GB for RAM
-            memory: 4096Mi
         env:
         - name: GIT_TOKEN
           valueFrom:


### PR DESCRIPTION
Reverts screwdriver-cd/executor-k8s#4

The limits we implemented are too high for the current infrastructure. This is to remove the limits until we can determine better settings for the configuration