### PR TITLE
Return 404 when pod with buildId does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const Executor = require('screwdriver-executor-base');
+const boom = require('boom');
 const fs = require('fs');
 const path = require('path');
 const request = require('request');
@@ -82,12 +83,12 @@ class K8sExecutor extends Executor {
 
         request.get(options, (err, resp, body) => {
             if (err) {
-                return response(new Error(`Error getting pod with sdbuild=${config.buildId}`));
+                return response(boom.wrap(err));
             }
             const podName = hoek.reach(body, 'items.0.metadata.name');
 
             if (!podName) {
-                return response(new Error(`Error getting pod name: ${JSON.stringify(body)}`));
+                return response(boom.notFound(`Unable to find build matching ${config.buildId}`));
             }
             const logUrl = `${podsUrl}/${podName}/log?container=build&follow=true&pretty=true`;
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
+    "boom": "^3.2.2",
     "hoek": "^4.0.1",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",


### PR DESCRIPTION
- Use boom to wrap error 
- Return 404 when podname is not found