### PR TITLE
Stream the Logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const Executor = require('screwdriver-executor-base');
 const fs = require('fs');
 const path = require('path');
+const Readable = require('stream').Readable;
 const request = require('request');
 const tinytim = require('tinytim');
 const yaml = require('js-yaml');
@@ -91,13 +92,13 @@ class K8sExecutor extends Executor {
             }
             const logUrl = `${podsUrl}/${podName}/log?container=build&follow=true&pretty=true`;
 
-            return request.get({
+            return response(new Readable().wrap(request.get({
                 url: logUrl,
                 headers: {
                     Authorization: `Bearer ${API_KEY}`
                 },
                 strictSSL: false
-            }).on('response', response);
+            })));
         });
     }
 }


### PR DESCRIPTION
This PR wraps the request.get function in a Readable stream that is passed back to the reply object

Currently, the implementation relies on a `.on('response')` event being called which only occurs once the entire log is loaded, and not for the stream