### PR TITLE
Add in circuit breakers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
+    "circuit-fuses": "1.0.0",
     "hoek": "^4.0.1",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",


### PR DESCRIPTION
This PR is integrating the circuit-breaker module from https://github.com/screwdriver-cd/circuit-fuses/pull/1

The PR is creating a fuse around calls to the Kubernetes cluster

I don't think it's possible to wrap the actual streaming of logs in a fuse because we need to be returning a readable stream of the Request.get object