### PR TITLE
Configure via Constructor; Use new Base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,66 @@
 
 > Kubernetes Executor plugin for Screwdriver
 
+This executor plugin extends the [executor-base-class], and provides methods to start jobs and stream logs
+from Kubernetes
+
 ## Usage
 
 ```bash
 npm install screwdriver-executor-k8s
 ```
+
+### Configure
+The class provides a couple options that are configurable in the instantiation of this Executor
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.token | String | The JWT token used for authenticating to the kubernetes cluster |
+| config.host | String | The hostname for the kubernetes cluster i.e. `kubernetes` if running inside kubernetes |
+
+### Start
+The `_start` method takes advantage of the input validation defined in the [executor-base-class].
+
+The parameters required are:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.buildId | String | The unique ID for a build |
+| config.jobId | String | The unique ID for a job |
+| config.pipelineId | String | The unique ID for a pipeline |
+| config.container | String | Container for the build to run in |
+| config.scmUrl | String | The scmUrl to checkout |
+| callback | Function | Callback `fn(err)` for when job has been created |
+
+The `_start` function will start a job in kubernetes with labels for easy lookup. These labels are:
+* sdbuild: config.buildId
+* sdjob: config.jobId
+* sdpipeline: config.pipelineId
+
+The job runs two containers:
+* Runs the [screwdriver job-tools] container, sharing the files in `/opt/screwdriver`
+* Runs the specified container (As of 7/21, only runs `node:4`), which runs `/opt/screwdriver/launch` with the required parameters
+
+The callback is called with:
+* An error `callback(err)` when an error occurs starting the job
+* null `callback(null)` when a job is correctly started
+
+### Stream
+The parameters required are:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.buildId | String | The unique ID for a build to stream logs for|
+| callback | Function | Callback `fn(err, stream)` for when stream has been created |
+
+The `_stream` function will call back with a Readable stream if a job exists with the `buildId` tag
+
+The callback is called with:
+* An error `callback(err)` when an error occurs fetching the logs
+* The stream `callback(null, readableStream)` when a stream is opened up for reading logs
 
 ## Testing
 
@@ -29,3 +84,5 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [wercker-url]: https://app.wercker.com/project/bykey/6eee5facca93cb34510bf36d814460e8
 [daviddm-image]: https://david-dm.org/screwdriver-cd/executor-k8s.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/executor-k8s
+[executor-base-class]: https://github.com/screwdriver-cd/executor-base
+[screwdriver job-tools]: https://github.com/screwdriver-cd/job-tools

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-k8s",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Kubernetes Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -44,7 +44,7 @@
     "hoek": "^4.0.1",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",
-    "screwdriver-executor-base": "0.0.4",
+    "screwdriver-executor-base": "^1.0.0",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,7 +86,10 @@ describe('index', () => {
         Executor = require('../index');
         /* eslint-enable global-require */
 
-        executor = new Executor();
+        executor = new Executor({
+            token: 'api_key',
+            host: 'kubernetes'
+        });
     });
 
     afterEach(() => {
@@ -131,7 +134,8 @@ describe('index', () => {
                     scmUrl: 'git@github.com:screwdriver-cd/hashr.git#addSD',
                     buildId: testBuildId,
                     jobId: testJobId,
-                    pipelineId: testPipelineId
+                    pipelineId: testPipelineId,
+                    container: 'container'
                 }, (err) => {
                     assert.isNull(err);
                     assert.calledOnce(breakRunMock);
@@ -162,7 +166,8 @@ describe('index', () => {
                     scmUrl: testScmUrl,
                     buildId: testBuildId,
                     jobId: testJobId,
-                    pipelineId: testPipelineId
+                    pipelineId: testPipelineId,
+                    container: 'container'
                 }, (err) => {
                     assert.isNull(err);
                     assert.calledOnce(breakRunMock);
@@ -181,7 +186,8 @@ describe('index', () => {
                 scmUrl: testScmUrl,
                 buildId: testBuildId,
                 jobId: testJobId,
-                pipelineId: testPipelineId
+                pipelineId: testPipelineId,
+                container: 'container'
             }, (err) => {
                 assert.deepEqual(err, error);
                 done();
@@ -204,7 +210,8 @@ describe('index', () => {
                 scmUrl: testScmUrl,
                 buildId: testBuildId,
                 jobId: testJobId,
-                pipelineId: testPipelineId
+                pipelineId: testPipelineId,
+                container: 'container'
             }, (err, response) => {
                 assert.notOk(response);
                 assert.equal(err.message, returnMessage);
@@ -286,7 +293,8 @@ describe('index', () => {
 
             executor.stream({
                 buildId: testBuildId
-            }, (stream) => {
+            }, (err, stream) => {
+                assert.isNull(err);
                 assert.calledOnce(breakRunMock);
                 assert.calledOnce(requestMock.get);
                 assert.calledWith(breakRunMock, getConfig);


### PR DESCRIPTION
Resolves #20 
Resolves #17 

This PR changes the configuration of the token and host to be done via the constructor of the object

It also adds in the new screwdriver-executor-base (https://github.com/screwdriver-cd/executor-base) class that enables input validation of executor functions

Also added in a README