### PR TITLE
[F1] Executing Launcher with new arguments (3rd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,17 @@ The parameters required are:
 | :-------------   | :---- | :-------------|
 | config        | Object | Configuration Object |
 | config.buildId | String | The unique ID for a build |
-| config.jobId | String | The unique ID for a job |
-| config.pipelineId | String | The unique ID for a pipeline |
 | config.container | String | Container for the build to run in |
-| config.scmUrl | String | The scmUrl to checkout |
-| callback | Function | Callback `fn(err)` for when job has been created |
+| config.apiUri | String | Screwdriver's API |
+| config.token | String | JWT to act on behalf of the build |
+| callback | Function | Callback for when task has been created |
 
 The `_start` function will start a job in kubernetes with labels for easy lookup. These labels are:
 * sdbuild: config.buildId
-* sdjob: config.jobId
-* sdpipeline: config.pipelineId
 
 The job runs two containers:
 * Runs the [screwdriver job-tools] container, sharing the files in `/opt/screwdriver`
-* Runs the specified container (As of 7/21, only runs `node:4`), which runs `/opt/screwdriver/launch` with the required parameters
+* Runs the specified container, which runs `/opt/screwdriver/launch` with the required parameters
 
 The callback is called with:
 * An error `callback(err)` when an error occurs starting the job

--- a/config/job.yaml.tim
+++ b/config/job.yaml.tim
@@ -4,21 +4,17 @@ metadata:
   name: {{build_id}}
   labels:
     sdbuild: {{build_id}}
-    sdjob: {{job_id}}
-    sdpipeline: {{pipeline_id}}
 spec:
   completions: 1
   template:
     metadata:
       labels:
         sdbuild: {{build_id}}
-        sdjob: {{job_id}}
-        sdpipeline: {{pipeline_id}}
     spec:
       restartPolicy: Never
       containers:
       - name: launcher
-        image: screwdrivercd/job-tools:v0.2.3
+        image: screwdrivercd/job-tools:{{version}}
         command:
         - "/bin/sh"
         - "-c"
@@ -28,15 +24,17 @@ spec:
           name: screwdriver
 
       - name: build
-        image: node:4
+        image: {{container}}
         command:
         - "/bin/sh"
         - "-c"
-        - "echo -n Fetching build tools.; while ! [ -f /opt/screwdriver/loaded ]; do echo -n .; sleep 1; done; echo; /opt/screwdriver/launch {{git_org}} {{git_repo}} {{git_branch}} {{job_name}}"
+        - "echo -n Fetching build tools.; while ! [ -f /opt/screwdriver/loaded ]; do echo -n .; sleep 1; done; echo; /opt/screwdriver/launch --api-uri {{api_uri}} {{build_id}}"
         volumeMounts:
         - mountPath: /opt/screwdriver
           name: screwdriver
         env:
+        - name: SD_TOKEN
+          value: "{{token}}"
         - name: GIT_TOKEN
           valueFrom:
             secretKeyRef:

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "screwdriver-executor-k8s",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Kubernetes Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive"
+  },
+  "engines": {
+    "node": ">=4.0.0"
   },
   "repository": {
     "type": "git",
@@ -33,7 +36,7 @@
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0",
+    "jenkins-mocha": "^3.0.0",
     "mockery": "^1.7.0",
     "sinon": "^1.17.4"
   },
@@ -42,7 +45,7 @@
     "hoek": "^4.0.1",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",
-    "screwdriver-executor-base": "^2.0.0",
+    "screwdriver-executor-base": "^3.0.0",
     "tinytim": "^0.1.1"
   }
 }


### PR DESCRIPTION
[Feature](https://github.com/screwdriver-cd/screwdriver/issues/77)

Passing:
 - buildId - Build Identifier (to look up stuff)
 - container - Container to start in
 - apiUri - URI to hit our API
 - token - Token to be able to read/write from the API

Blocked on https://github.com/screwdriver-cd/executor-base/pull/13

@jer I need the expected version of the JobTools that will contain this new launcher