### PR TITLE
Executor Stops

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,42 @@ class K8sExecutor extends Executor {
     }
 
     /**
+     * Stop a k8s build
+     * @method stop
+     * @param  {Object}   config            A configuration object
+     * @param  {String}   config.buildId    ID for the build
+     * @param  {Function} callback          Callback function
+     */
+    _stop(config, callback) {
+        const options = {
+            uri: this.jobsUrl,
+            method: 'DELETE',
+            qs: {
+                labelSelector: `sdbuild=${config.buildId}`
+            },
+            headers: {
+                Authorization: `Bearer ${this.token}`
+            },
+            strictSSL: false
+        };
+
+        // @TODO collect logs before removing all traces of it.
+        this.breaker.runCommand(options, (err, resp) => {
+            if (err) {
+                return callback(err);
+            }
+
+            if (resp.statusCode !== 200) {
+                const msg = `Failed to delete job: ${JSON.stringify(resp.body)}`;
+
+                return callback(new Error(msg));
+            }
+
+            return callback(null);
+        });
+    }
+
+    /**
     * Streams logs
     * @method stream
     * @param  {Object}   config            A configuration object

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,12 +37,6 @@ describe('index', () => {
     const testJobId = '2eda8ad1632af052b0c74d6fcab6058b3a79cf25';
     const testPipelineId = 'aaa83eac6890a9a6e2273ea51d6f2f2915b1a019';
     const testJobName = 'main';
-    const fakeResponse = {
-        statusCode: 201,
-        body: {
-            success: true
-        }
-    };
     const jobsUrl = 'https://kubernetes/apis/batch/v1/namespaces/default/jobs';
     const podsUrl = 'https://kubernetes/api/v1/namespaces/default/pods';
 
@@ -107,9 +101,85 @@ describe('index', () => {
         assert.isFunction(executor.start);
     });
 
-    describe('start', () => {
+    describe('stop', () => {
+        const fakeStopResponse = {
+            statusCode: 200,
+            body: {
+                success: 'true'
+            }
+        };
+        const deleteConfig = {
+            uri: jobsUrl,
+            method: 'DELETE',
+            qs: {
+                labelSelector: `sdbuild=${testBuildId}`
+            },
+            headers: {
+                Authorization: 'Bearer api_key'
+            },
+            strictSSL: false
+        };
+
         beforeEach(() => {
-            breakRunMock.yieldsAsync(null, fakeResponse, fakeResponse.body);
+            breakRunMock.yieldsAsync(null, fakeStopResponse, fakeStopResponse.body);
+        });
+
+        it('calls breaker with correct config', (done) => {
+            executor.stop({
+                buildId: testBuildId
+            }, (err) => {
+                assert.isNull(err);
+                assert.calledOnce(breakRunMock);
+                assert.calledWith(breakRunMock, deleteConfig);
+                done();
+            });
+        });
+
+        it('returns error when breaker does', (done) => {
+            const error = new Error('error');
+
+            breakRunMock.yieldsAsync(error);
+            executor.stop({
+                buildId: testBuildId
+            }, (err) => {
+                assert.deepEqual(err, error);
+                assert.calledOnce(breakRunMock);
+                done();
+            });
+        });
+
+        it('returns error when response is non 200', (done) => {
+            const fakeStopErrorResponse = {
+                statusCode: 500,
+                body: {
+                    error: 'foo'
+                }
+            };
+
+            const returnMessage = 'Failed to delete job: '
+                  + `${JSON.stringify(fakeStopErrorResponse.body)}`;
+
+            breakRunMock.yieldsAsync(null, fakeStopErrorResponse);
+
+            executor.stop({
+                buildId: testBuildId
+            }, (err) => {
+                assert.equal(err.message, returnMessage);
+                done();
+            });
+        });
+    });
+
+    describe('start', () => {
+        const fakeStartResponse = {
+            statusCode: 201,
+            body: {
+                success: true
+            }
+        };
+
+        beforeEach(() => {
+            breakRunMock.yieldsAsync(null, fakeStartResponse, fakeStartResponse.body);
         });
 
         describe('successful requests', () => {


### PR DESCRIPTION
This PR adds in an executor stop function for the executor-k8s

It calls delete on the jobUri endpoint including a labelSelector for the `sdbuild` that is set in the _start function