### PR TITLE
Add getter for breaker stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,27 @@ class K8sExecutor extends Executor {
             })));
         });
     }
+
+    /**
+    * Retreive stats for the executor
+    * @method stats
+    * @param  {Response} Object          Object containing stats for the executor
+    */
+    stats() {
+        return {
+            requests: {
+                total: this.breaker.getTotalRequests(),
+                timeouts: this.breaker.getTimeouts(),
+                success: this.breaker.getSuccessfulRequests(),
+                failure: this.breaker.getFailedRequests(),
+                concurrent: this.breaker.getConcurrentRequests(),
+                averageTime: this.breaker.getAverageRequestTime()
+            },
+            breaker: {
+                isClosed: this.breaker.isClosed()
+            }
+        };
+    }
 }
 
 module.exports = K8sExecutor;


### PR DESCRIPTION
This PR adds in a getter for the executor that retrieves stats of the circuit breaker being used.

The functions called on the breaker are exposed via the circuit-fuses class https://github.com/screwdriver-cd/circuit-fuses

I'm not sure if we want to standardize in the `executor-base` to have a stats method, but this is a start