### PR TITLE
Simplifying the Kubernetes config and using the new store API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ The class provides a couple options that are configurable in the instantiation o
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | config        | Object | Configuration Object |
-| config.token | String | The JWT token used for authenticating to the Kubernetes cluster (content of `/var/run/secrets/kubernetes.io/serviceaccount/token`) |
-| config.host | String | The hostname for the Kubernetes cluster (kubernetes) |
-| config.toolsVersion | String | Job Tools container version to use (stable) |
-| config.logVersion | String | Log Service container version to use (stable) |
+| config.kubernetes | Object | Kubernetes configuration Object |
+| config.kubernetes.token | String | The JWT token used for authenticating to the Kubernetes cluster (content of `/var/run/secrets/kubernetes.io/serviceaccount/token`) |
+| config.kubernetes.host | String | The hostname for the Kubernetes cluster (kubernetes) |
+| config.kubernetes.serviceAccount | String | The service account to use in Kubernetes (default) |
+| config.ecosystem | Object | Screwdriver Ecosystem (ui, api, store, etc.) |
+| config.launchVersion | String | Launcher container version to use (stable) |
 
 
 ### Methods

--- a/config/job.yaml.tim
+++ b/config/job.yaml.tim
@@ -19,15 +19,11 @@ spec:
           {
             "name": "launcher",
             "image": "screwdrivercd/launcher:{{launcher_version}}",
-            "command": ["/bin/sh", "-c", "cp -a /opt/screwdriver/* /opt/launcher && mkfifo /var/run/sd/emitter"],
+            "command": ["/bin/sh", "-c", "cp -a /opt/screwdriver/* /opt/launcher],
             "volumeMounts": [
               {
                 "name": "screwdriver",
                 "mountPath": "/opt/launcher"
-              },
-              {
-                "name": "bucket",
-                "mountPath": "/var/run/sd"
               }
             ]
           }
@@ -44,43 +40,20 @@ spec:
         command:
         - "/opt/screwdriver/tini"
         - "--"
-        - "/opt/screwdriver/launch"
-        - "--emitter"
-        - "/var/run/sd/emitter"
-        - "--api-uri"
-        - "{{api_uri}}"
-        - "{{build_id}}"
+        - '/bin/sh',
+        - '-c',
+        # Run the launcher and logservice in the background
+        # Wait for both background jobs to complete
+        - |
+          /opt/screwdriver/launch --api-uri {{api_uri}} --emitter /opt/screwdriver/emitter {{build_id}} &
+          /opt/screwdriver/logservice --emitter /opt/screwdriver/emitter --api-uri {{store_uri}} --build {{build_id}} &
+          wait $(jobs -p)
         volumeMounts:
         - mountPath: /opt/screwdriver
           name: screwdriver
-        - mountPath: /var/run/sd
-          name: bucket
         env:
         - name: SD_TOKEN
           value: "{{token}}"
-      - name: logservice
-        image: screwdrivercd/log-service:{{log_version}}
-        resources:
-          limits:
-            memory: 200Mi
-        command:
-        - "/opt/screwdriver/tini"
-        - "--"
-        - "/opt/screwdriver/logservice"
-        - "--emitter"
-        - "/var/run/sd/emitter"
-        - "--api-uri"
-        - "{{api_uri}}"
-        - "--build"
-        - "{{build_id}}"
-        env:
-        - name: SD_TOKEN
-          value: "{{token}}"
-        volumeMounts:
-        - mountPath: /var/run/sd
-          name: bucket
       volumes:
         - name: screwdriver
-          emptyDir: {}
-        - name: bucket
           emptyDir: {}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,10 +11,9 @@ metadata:
   name: {{build_id}}
   container: {{container}}
   launchVersion: {{launcher_version}}
-  logVersion: {{log_version}}
   serviceAccount: {{service_account}}
 command:
-- "/opt/screwdriver/launch {{api_uri}} {{token}} {{build_id}}"
+- "/opt/screwdriver/launch {{api_uri}} {{store_uri}} {{token}} {{build_id}}"
 `;
 
 describe('index', () => {
@@ -24,10 +23,10 @@ describe('index', () => {
     let executor;
     const testBuildId = '80754af91bfb6d1073585b046fe0a474ce868509';
     const testToken = 'abcdefg';
-    const testApiUri = 'http://localhost:8080';
+    const testApiUri = 'http://api:8080';
+    const testStoreUri = 'http://store:8080';
     const testContainer = 'node:4';
     const testLaunchVersion = 'stable';
-    const testLogVersion = 'stable';
     const testServiceAccount = 'default';
     const jobsUrl = 'https://kubernetes/apis/batch/v1/namespaces/default/jobs';
 
@@ -58,6 +57,10 @@ describe('index', () => {
         /* eslint-enable global-require */
 
         executor = new Executor({
+            ecosystem: {
+                api: testApiUri,
+                store: testStoreUri
+            },
             fusebox: { retry: { minTimeout: 1 } }
         });
     });
@@ -73,21 +76,20 @@ describe('index', () => {
 
     it('supports specifying a specific version', () => {
         assert.equal(executor.launchVersion, 'stable');
-        assert.equal(executor.logVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
         assert.equal(executor.token, 'api_key');
         assert.equal(executor.host, 'kubernetes');
         executor = new Executor({
-            token: 'api_key2',
-            host: 'kubernetes2',
-            launchVersion: 'v1.2.3',
-            logVersion: 'v2.3.4',
-            serviceAccount: 'foobar'
+            kubernetes: {
+                token: 'api_key2',
+                host: 'kubernetes2',
+                serviceAccount: 'foobar'
+            },
+            launchVersion: 'v1.2.3'
         });
         assert.equal(executor.token, 'api_key2');
         assert.equal(executor.host, 'kubernetes2');
         assert.equal(executor.launchVersion, 'v1.2.3');
-        assert.equal(executor.logVersion, 'v2.3.4');
         assert.equal(executor.serviceAccount, 'foobar');
     });
 
@@ -205,11 +207,11 @@ describe('index', () => {
                         name: testBuildId,
                         container: testContainer,
                         launchVersion: testLaunchVersion,
-                        logVersion: testLogVersion,
                         serviceAccount: testServiceAccount
                     },
                     command: [
-                        `/opt/screwdriver/launch ${testApiUri} ${testToken} ${testBuildId}`
+                        '/opt/screwdriver/launch http://api:8080 http://store:8080 abcdefg '
+                        + '80754af91bfb6d1073585b046fe0a474ce868509'
                     ]
                 },
                 headers: {


### PR DESCRIPTION
- No longer using logVersion
- No longer creating log container
- Using api and store from ecosystem
- Scoping Kubernetes config in constructor

Not bumping major because not included in SD yet. https://github.com/screwdriver-cd/screwdriver/pull/270