### PR TITLE
fix: Switching to /opt/sd to prevent collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 10.0.0
+
+Breaking Change:
+ - Requires Launcher version 3.* due to new volume location

--- a/config/job.yaml.tim
+++ b/config/job.yaml.tim
@@ -19,7 +19,7 @@ spec:
           {
             "name": "launcher",
             "image": "screwdrivercd/launcher:{{launcher_version}}",
-            "command": ["/bin/sh", "-c", "cp -a /opt/screwdriver/* /opt/launcher"],
+            "command": ["/bin/sh", "-c", "cp -a /opt/sd/* /opt/launcher"],
             "volumeMounts": [
               {
                 "name": "screwdriver",
@@ -38,18 +38,18 @@ spec:
           limits:
             memory: 2Gi
         command:
-        - "/opt/screwdriver/tini"
+        - "/opt/sd/tini"
         - "--"
         - "/bin/sh"
         - "-c"
         # Run the launcher and logservice in the background
         # Wait for both background jobs to complete
         - |
-          /opt/screwdriver/launch --api-uri {{api_uri}} --emitter /opt/screwdriver/emitter {{build_id}} &
-          /opt/screwdriver/logservice --emitter /opt/screwdriver/emitter --api-uri {{store_uri}} --build {{build_id}} &
+          /opt/sd/launch --api-uri {{api_uri}} --emitter /opt/sd/emitter {{build_id}} &
+          /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{store_uri}} --build {{build_id}} &
           wait $(jobs -p)
         volumeMounts:
-        - mountPath: /opt/screwdriver
+        - mountPath: /opt/sd
           name: screwdriver
         env:
         - name: SD_TOKEN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-k8s",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Kubernetes Executor plugin for Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,6 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
     "jenkins-mocha": "^3.0.0",
     "mockery": "^2.0.0",
     "sinon": "^1.17.4"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,7 @@ metadata:
   launchVersion: {{launcher_version}}
   serviceAccount: {{service_account}}
 command:
-- "/opt/screwdriver/launch {{api_uri}} {{store_uri}} {{token}} {{build_id}}"
+- "/opt/sd/launch {{api_uri}} {{store_uri}} {{token}} {{build_id}}"
 `;
 
 describe('index', () => {
@@ -212,7 +212,7 @@ describe('index', () => {
                         serviceAccount: testServiceAccount
                     },
                     command: [
-                        '/opt/screwdriver/launch http://api:8080 http://store:8080 abcdefg '
+                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
                         + '80754af91bfb6d1073585b046fe0a474ce868509'
                     ]
                 },


### PR DESCRIPTION
We have some legacy containers with contents in `/opt/screwdriver`.  This changes the mounted location to `/opt/sd` to prevent any namespace collisions.