### PR TITLE
fix: add double quote for buildId(number)

### DIFF
--- a/config/job.yaml.tim
+++ b/config/job.yaml.tim
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{build_id}}
+  name: "{{build_id}}"
   labels:
-    sdbuild: {{build_id}}
+    sdbuild: "{{build_id}}"
     app: screwdriver
     tier: builds
 spec:
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        sdbuild: {{build_id}}
+        sdbuild: "{{build_id}}"
         app: screwdriver
         tier: builds
       annotations:


### PR DESCRIPTION
- We now have buildId as number which failed the job template for kubernetes
- Add double quote to make it a string