### PR TITLE
fix: enable rwx for all in /opt/sd path

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -11,7 +11,7 @@ metadata:
       {
         "name": "launcher",
         "image": "screwdrivercd/launcher:{{launcher_version}}",
-        "command": ["/bin/sh", "-c", "cp -a /opt/sd/* /opt/launcher"],
+        "command": ["/bin/sh", "-c", "cp -a /opt/sd/* /opt/launcher && chmod 777 /opt/sd"],
         "volumeMounts": [
           {
             "name": "screwdriver",


### PR DESCRIPTION
## Context

SDCD allows any build image to be used to run their pipeline with. Some build images will have a default non-root user. This has lead to the scenario that a SDCD build will need to create some folders and files where root privilege is needed.

## Objective

This is to ensure that the /opt/sd path is writable by all. This allows
any user to be able to run the typical SDCD operations (e.g., create
workspace, emitter socket, etc.) without the need to provide a mix of
elevated privileges for a non-root user.