### PR TITLE
fix(604): set token to empty if no token in config and tokenPath not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ npm install screwdriver-executor-k8s
 ### Initialization
 The class provides a couple options that are configurable in the instantiation of this Executor
 
-| Parameter        | Type  |  Description |
-| :-------------   | :---- | :-------------|
-| config        | Object | Configuration Object |
-| config.kubernetes | Object | Kubernetes configuration Object |
-| config.kubernetes.token | String | The JWT token used for authenticating to the Kubernetes cluster (content of `/var/run/secrets/kubernetes.io/serviceaccount/token`) |
-| config.kubernetes.host | String | The hostname for the Kubernetes cluster (kubernetes) |
-| config.kubernetes.serviceAccount | String | The service account to use in Kubernetes (default) |
-| config.ecosystem | Object | Screwdriver Ecosystem (ui, api, store, etc.) |
-| config.launchVersion | String | Launcher container version to use (stable) |
-| config.prefix | String | Prefix to container names ("") |
+| Parameter        | Type  | Default    | Description |
+| :-------------   | :---- | :----------| :-----------|
+| config        | Object | | Configuration Object |
+| config.kubernetes | Object | {} | Kubernetes configuration Object |
+| config.kubernetes.token | String | '' | The JWT token used for authenticating to the Kubernetes cluster. (If not passed in, we will read from `/var/run/secrets/kubernetes.io/serviceaccount/token`.) |
+| config.kubernetes.host | String | 'kubernetes.defaults' | The hostname for the Kubernetes cluster (kubernetes) |
+| config.kubernetes.serviceAccount | String | 'default' | The service account to use in Kubernetes (default) |
+| config.ecosystem | Object | | Screwdriver Ecosystem (ui, api, store, etc.) |
+| config.launchVersion | String | 'stable' | Launcher container version to use (stable) |
+| config.prefix | String | '' | Prefix to container names ("") |
+| config.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |
 
 
 ### Methods

--- a/index.js
+++ b/index.js
@@ -30,8 +30,13 @@ class K8sExecutor extends Executor {
 
         this.kubernetes = options.kubernetes || {};
         this.ecosystem = options.ecosystem;
-        this.token = this.kubernetes.token ||
-            fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token').toString();
+        if (this.kubernetes.token) {
+            this.token = this.kubernetes.token;
+        } else {
+            const tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+
+            this.token = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath).toString() : '';
+        }
         this.host = this.kubernetes.host || 'kubernetes.default';
         this.launchVersion = options.launchVersion || 'stable';
         this.prefix = options.prefix || '';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,8 +44,11 @@ describe('index', function () {
         requestMock = sinon.stub();
 
         fsMock = {
+            existsSync: sinon.stub(),
             readFileSync: sinon.stub()
         };
+
+        fsMock.existsSync.returns(true);
 
         fsMock.readFileSync.withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token')
             .returns('api_key');
@@ -102,10 +105,11 @@ describe('index', function () {
     });
 
     it('allow empty options', () => {
+        fsMock.existsSync.returns(false);
         executor = new Executor();
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
-        assert.equal(executor.token, 'api_key');
+        assert.equal(executor.token, '');
         assert.equal(executor.host, 'kubernetes.default');
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.prefix, '');


### PR DESCRIPTION
`executor-router` will require all `executor plugins` no matter what default you pick. So when I test it locally using docker as my default, it complains that `/var/run/secrets/kubernetes.io/serviceaccount/token` does not exist which is annoying and does not make any sense.

This PR will check if the path exist, if not, set the token to `empty`.

Related to https://github.com/screwdriver-cd/screwdriver/issues/604