### PR TITLE
feat: Add HIGH resource for cpu and ram

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -28,7 +28,8 @@ spec:
     image: {{container}}
     resources:
       limits:
-        memory: 2Gi
+        cpu: {{cpu}}
+        memory: {{memory}}Gi
     command:
     - "/opt/sd/tini"
     - "--"

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -28,7 +28,7 @@ spec:
     image: {{container}}
     resources:
       limits:
-        cpu: {{cpu}}
+        cpu: {{cpu}}m
         memory: {{memory}}Gi
     command:
     - "/opt/sd/tini"

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ class K8sExecutor extends Executor {
     _start(config) {
         const cpuConfig = hoek.reach(config, 'annotations', { default: {} })[CPU_RESOURCE];
         const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
-        const CPU = (cpuConfig === 'HIGH') ? 6 : 2;
+        const CPU = (cpuConfig === 'HIGH') ? 6000 : 2000; // 6000 millicpu or 2000 millicpu
         const MEMORY = (ramConfig === 'HIGH') ? 12 : 2;   // 12GB or 2GB
         const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
             build_id_with_prefix: `${this.prefix}${config.buildId}`,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ const request = require('request');
 const tinytim = require('tinytim');
 const yaml = require('js-yaml');
 const fs = require('fs');
+const hoek = require('hoek');
+
+const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
+const RAM_RESOURCE = 'beta.screwdriver.cd/ram';
 
 class K8sExecutor extends Executor {
     /**
@@ -56,6 +60,10 @@ class K8sExecutor extends Executor {
      * @return {Promise}
      */
     _start(config) {
+        const cpuConfig = hoek.reach(config, 'annotations', { default: {} })[CPU_RESOURCE];
+        const ramConfig = hoek.reach(config, 'annotations', { default: {} })[RAM_RESOURCE];
+        const CPU = (cpuConfig === 'HIGH') ? 6 : 2;
+        const MEMORY = (ramConfig === 'HIGH') ? 12 : 2;   // 12GB or 2GB
         const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
             build_id_with_prefix: `${this.prefix}${config.buildId}`,
             build_id: config.buildId,
@@ -64,7 +72,9 @@ class K8sExecutor extends Executor {
             store_uri: this.ecosystem.store,
             token: config.token,
             launcher_version: this.launchVersion,
-            service_account: this.serviceAccount
+            service_account: this.serviceAccount,
+            cpu: CPU,
+            memory: MEMORY
         });
 
         const options = {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.1.0",
+    "hoek": "^5.0.2",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",
     "screwdriver-executor-base": "^5.2.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -226,7 +226,7 @@ describe('index', function () {
                     container: testContainer,
                     launchVersion: testLaunchVersion,
                     serviceAccount: testServiceAccount,
-                    cpu: 2,
+                    cpu: 2000,
                     memory: 2
                 },
                 command: [
@@ -257,7 +257,7 @@ describe('index', function () {
         });
 
         it('sets the memory appropriately when ram is set to HIGH', () => {
-            postConfig.json.metadata.cpu = 2;
+            postConfig.json.metadata.cpu = 2000;
             postConfig.json.metadata.memory = 12;
 
             return executor.start({
@@ -274,8 +274,8 @@ describe('index', function () {
             });
         });
 
-        it('sets the memory appropriately when cpu is set to HIGH', () => {
-            postConfig.json.metadata.cpu = 6;
+        it('sets the cpu appropriately when cpu is set to HIGH', () => {
+            postConfig.json.metadata.cpu = 6000;
             postConfig.json.metadata.memory = 2;
 
             return executor.start({


### PR DESCRIPTION
We mainly use `k8s-executor` plugin in our cluster, and some builds fail due to lack of resources.
So, This PR add `HIGH` resource for cpu and ram to `k8s` executor just like [k8s-vm](https://github.com/screwdriver-cd/executor-k8s-vm/pull/10).

### References
[758](https://github.com/screwdriver-cd/screwdriver/issues/758), [759](https://github.com/screwdriver-cd/screwdriver/issues/759)