### PR TITLE
fix: use semantic-release template for publish

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
Newer version of `semantic-release` package requires node>=8,
so I fixed to use `semantic-release` template like [this](https://github.com/screwdriver-cd/executor-k8s-vm/pull/9).
https://cd.screwdriver.cd/pipelines/28/builds/13391