### PR TITLE
fix: update syntax of Init Containers 

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -6,20 +6,6 @@ metadata:
     sdbuild: "{{build_id_with_prefix}}"
     app: screwdriver
     tier: builds
-  annotations:
-    pod.alpha.kubernetes.io/init-containers: '[
-      {
-        "name": "launcher",
-        "image": "screwdrivercd/launcher:{{launcher_version}}",
-        "command": ["/bin/sh", "-c", "cp -a /opt/sd/* /opt/launcher"],
-        "volumeMounts": [
-          {
-            "name": "screwdriver",
-            "mountPath": "/opt/launcher"
-          }
-        ]
-      }
-    ]'
 spec:
   serviceAccount: {{service_account}}
   restartPolicy: Never
@@ -49,6 +35,13 @@ spec:
     env:
     - name: SD_TOKEN
       value: "{{token}}"
+  initContainers:
+  - name: launcher
+    image: screwdrivercd/launcher:{{launcher_version}}
+    command: ['/bin/sh', '-c', 'cp -a /opt/sd/* /opt/launcher']
+    volumeMounts:
+    - mountPath: /opt/launcher
+      name: screwdriver
   volumes:
     - name: screwdriver
       emptyDir: {}


### PR DESCRIPTION
### Context
Screwdriver.cd is now using Init Containers with alpha annotations, but alpha annotations are not supported in Kubernetes 1.8 or greater.

### Objective
Use new syntax of Init Containers.
Please refer to https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

### Note
- This new syntax doesn't work in Kubernetes 1.5
- same as https://github.com/screwdriver-cd/executor-k8s-vm/pull/16