### PR TITLE
feat: set store uri when launch

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -24,7 +24,7 @@ spec:
     # Run the launcher and logservice in the background
     # Wait for both background jobs to complete
     - |
-      /opt/sd/launch --api-uri {{api_uri}} --emitter /opt/sd/emitter {{build_id}} &
+      /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
       /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{store_uri}} --build {{build_id}} &
       wait $(jobs -p)
     volumeMounts:


### PR DESCRIPTION
## Context
Add store url argument when call launch command.

We need to use store url when use sd-cmd. 
By this [PR](https://github.com/screwdriver-cd/launcher/pull/138), we can set store api. 

## Objective
Call launch command with `--store-uri` argument.

## References
[launcher PR for store url argument](https://github.com/screwdriver-cd/launcher/pull/138)