### PR TITLE
Fix imagePullPolicy setting to "Always"

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -12,6 +12,7 @@ spec:
   containers:
   - name: build
     image: {{container}}
+    imagePullPolicy: Always
     resources:
       limits:
         cpu: {{cpu}}m


### PR DESCRIPTION
## Context
Some users want to use public docker images with floating tags that we don't recommend to use on Screwdriver.cd including "node:8" and "python:3.4".
But they are very convenient to use for users who want to keep their build environment the latest.

For example, given the job that uses "node:8".
Each build may use different images every time the case some nodes have "node:8" in their cache and others don't. It makes users confusing.

## Changes
I added new settings `imagePullPolicy` and set it to `Always`.  Every builds on Kubernetes executor will confirm for the update by this change.
This resolves screwdriver-cd/screwdriver#869.