### PR TITLE
feat: annotation for customizing build timeouts

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -25,7 +25,7 @@ spec:
     # Run the launcher and logservice in the background
     # Wait for both background jobs to complete
     - |
-      /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} &
+      /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter {{build_id}} --build-timeout {{build_timeout}} &
       /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{store_uri}} --build {{build_id}} &
       wait $(jobs -p)
     volumeMounts:


### PR DESCRIPTION
## Context

Build timeouts have a default value of 5400 seconds. We want to allow users to override the value. Eventually we will put in efforts to enforce boundaries on these values.

## Objective

Use an annotation for users to configure their own timeouts. Default is 5400 seconds.

## Reference

* Feature issue
   * https://github.com/screwdriver-cd/screwdriver/issues/545
* Hyperctl parameter for build timeout
   * https://github.com/screwdriver-cd/hyperctl-image/pull/19

