### PR TITLE
fix: build timeout units are in minutes

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const hoek = require('hoek');
 
 const ANNOTATE_BUILD_TIMEOUT = 'beta.screwdriver.cd/timeout';
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
-const DEFAULT_BUILD_TIMEOUT = 5400;     // 90 minutes in seconds
+const DEFAULT_BUILD_TIMEOUT = 90;     // 90 minutes
 const RAM_RESOURCE = 'beta.screwdriver.cd/ram';
 
 class K8sExecutor extends Executor {
@@ -23,7 +23,7 @@ class K8sExecutor extends Executor {
      * @param  {Object} options.ecosystem.api                         Routable URI to Screwdriver API
      * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.kubernetes                            Kubernetes configuration
-     * @param  {Number} [options.kubernetes.buildTimeout=5400]        Number of seconds to allow a build to run before considering it is timed out
+     * @param  {Number} [options.kubernetes.buildTimeout=90]          Number of minutes to allow a build to run before considering it is timed out
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
      * @param  {String} [options.kubernetes.host=kubernetes.default]  Kubernetes hostname
      * @param  {String} [options.kubernetes.serviceAccount=default]   Service Account for builds

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,7 +90,7 @@ describe('index', function () {
         assert.equal(executor.host, 'kubernetes.default');
         executor = new Executor({
             kubernetes: {
-                buildTimeout: 3600,
+                buildTimeout: 12,
                 token: 'api_key2',
                 host: 'kubernetes2',
                 serviceAccount: 'foobar',
@@ -109,7 +109,7 @@ describe('index', function () {
             prefix: 'beta_',
             launchVersion: 'v1.2.3'
         });
-        assert.equal(executor.buildTimeout, 3600);
+        assert.equal(executor.buildTimeout, 12);
         assert.equal(executor.prefix, 'beta_');
         assert.equal(executor.token, 'api_key2');
         assert.equal(executor.host, 'kubernetes2');
@@ -125,7 +125,7 @@ describe('index', function () {
     it('allow empty options', () => {
         fsMock.existsSync.returns(false);
         executor = new Executor();
-        assert.equal(executor.buildTimeout, 5400);
+        assert.equal(executor.buildTimeout, 90);
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
         assert.equal(executor.token, '');
@@ -254,7 +254,7 @@ describe('index', function () {
                         memory: 2
                     },
                     command: [
-                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 5400 '
+                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 90 '
                         + '15'
                     ]
                 },


### PR DESCRIPTION
## Context

The units of time for `build-timeout` is in minutes.

## Objective

Correct all assumptions of _build-timeout_ from seconds to minutes.

## References

* Feature issue
   * https://github.com/screwdriver-cd/screwdriver/issues/545