### PR TITLE
feat(845) use tolerations config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,14 @@
     "eslint-config-screwdriver": "^2.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
+    "rewire": "^3.0.2",
     "sinon": "^1.17.4"
   },
   "dependencies": {
     "circuit-fuses": "^2.1.0",
     "hoek": "^5.0.2",
-    "js-yaml": "^3.6.1",
+    "js-yaml": "^3.11.0",
+    "lodash": "^4.17.5",
     "request": "^2.72.0",
     "screwdriver-executor-base": "^5.2.0",
     "tinytim": "^0.1.1"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,19 +1,17 @@
-workflow:
-    - publish
-
 shared:
-    image: node:6
+  image: node:6
 
 jobs:
-    main:
-        steps:
-            - install: npm install
-            - test: npm test
-
-    publish:
-        template: screwdriver-cd/semantic-release 
-        secrets:
-            # Publishing to NPM
-            - NPM_TOKEN
-            # Pushing tags to Git
-            - GH_TOKEN
+  main:
+    requires: [ ~pr, ~commit ]
+    steps:
+      - install: npm install
+      - test: npm test
+  publish:
+    requires: [ main ]
+    template: screwdriver-cd/semantic-release
+    secrets:
+      # Publishing to NPM
+      - NPM_TOKEN
+      # Pushing tags to Git
+      - GH_TOKEN


### PR DESCRIPTION
## Context
`executor-k8s` does not support adding tolerations config.

## Objective
This PR adds tolerations config and refactor.

## References
Related: https://github.com/screwdriver-cd/screwdriver/issues/845
Similar Update: https://github.com/screwdriver-cd/executor-k8s-vm/pull/19