### PR TITLE
fix(972): fix when a selector is empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ const PREFERRED_WEIGHT = 100;
  * @param {Object} nodeSelectors  key-value pairs of node selectors
  */
 function setNodeSelector(podConfig, nodeSelectors) {
-    if (!nodeSelectors || typeof nodeSelectors !== 'object') {
+    if (!nodeSelectors || typeof nodeSelectors !== 'object' ||
+        Object.keys(nodeSelectors).length === 0) {
         return;
     }
 
@@ -65,7 +66,8 @@ function setNodeSelector(podConfig, nodeSelectors) {
  * @param {Object} preferredNodeSelectors key-value pairs of preferred node selectors
  */
 function setPreferredNodeSelector(podConfig, preferredNodeSelectors) {
-    if (!preferredNodeSelectors || typeof preferredNodeSelectors !== 'object') {
+    if (!preferredNodeSelectors || typeof preferredNodeSelectors !== 'object' ||
+        Object.keys(preferredNodeSelectors).length === 0) {
         return;
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,6 +119,10 @@ describe('index', function () {
                 api: testApiUri,
                 store: testStoreUri
             },
+            kubernetes: {
+                nodeSelectors: {},
+                preferredNodeSelectors: {}
+            },
             fusebox: { retry: { minTimeout: 1 } },
             prefix: 'beta_'
         });


### PR DESCRIPTION
The default  `nodeSelectors` and `preferredNodeSelectors` are `{}`. It creates empty affinity configs so it causes this error.
```
 Failed to create pod: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod \"3\" is invalid: spec.affinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms: Required value: must have at least one node selector term","reason":"Invalid","details":{"name":"3","kind":"Pod","causes":[{"reason":"FieldValueRequired","message":"Required value: must have at least one node selector term","field":"spec.affinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms"}]},"code":422}
```

This PR fixes this problem.

Related: https://github.com/screwdriver-cd/screwdriver/issues/972