### PR TITLE
fix(545): support cluster timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,9 @@ class K8sExecutor extends Executor {
      */
     _start(config) {
         const annotations = hoek.reach(config, 'annotations', { default: {} });
-        const buildTimeout = annotations[ANNOTATE_BUILD_TIMEOUT] || this.buildTimeout;
+        const buildTimeout = annotations[ANNOTATE_BUILD_TIMEOUT]
+            ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.buildTimeout)
+            : this.buildTimeout;
         const cpuConfig = annotations[CPU_RESOURCE];
         const CPU = (cpuConfig === 'HIGH') ? this.highCpu * 1000 : this.lowCpu * 1000; // 6000 millicpu or 2000 millicpu
         const MEMORY = (annotations[RAM_RESOURCE] === 'HIGH') ? this.highMemory : this.lowMemory;      // 12GB or 2GB

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const _ = require('lodash');
 const ANNOTATE_BUILD_TIMEOUT = 'beta.screwdriver.cd/timeout';
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
 const DEFAULT_BUILD_TIMEOUT = 90;     // 90 minutes
+const MAX_BUILD_TIMEOUT = 120;        // 120 minutes
 const RAM_RESOURCE = 'beta.screwdriver.cd/ram';
 
 const TOLERATIONS_PATH = 'spec.tolerations';
@@ -108,6 +109,7 @@ class K8sExecutor extends Executor {
      * @param  {Object} options.ecosystem.store                       Routable URI to Screwdriver Store
      * @param  {Object} options.kubernetes                            Kubernetes configuration
      * @param  {Number} [options.kubernetes.buildTimeout=90]          Number of minutes to allow a build to run before considering it is timed out
+     * @param  {Number} [options.kubernetes.maxBuildTimeout=120]      Max timeout user can configure up to
      * @param  {String} [options.kubernetes.token]                    API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
      * @param  {String} [options.kubernetes.host=kubernetes.default]  Kubernetes hostname
      * @param  {String} [options.kubernetes.serviceAccount=default]   Service Account for builds
@@ -133,6 +135,7 @@ class K8sExecutor extends Executor {
             this.token = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath).toString() : '';
         }
         this.buildTimeout = hoek.reach(options, 'kubernetes.buildTimeout') || DEFAULT_BUILD_TIMEOUT;
+        this.maxBuildTimeout = this.kubernetes.maxBuildTimeout || MAX_BUILD_TIMEOUT;
         this.host = this.kubernetes.host || 'kubernetes.default';
         this.launchVersion = options.launchVersion || 'stable';
         this.prefix = options.prefix || '';
@@ -160,7 +163,7 @@ class K8sExecutor extends Executor {
     _start(config) {
         const annotations = hoek.reach(config, 'annotations', { default: {} });
         const buildTimeout = annotations[ANNOTATE_BUILD_TIMEOUT]
-            ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.buildTimeout)
+            ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.maxBuildTimeout)
             : this.buildTimeout;
         const cpuConfig = annotations[CPU_RESOURCE];
         const CPU = (cpuConfig === 'HIGH') ? this.highCpu * 1000 : this.lowCpu * 1000; // 6000 millicpu or 2000 millicpu

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -376,7 +376,8 @@ describe('index', function () {
             executor.buildTimeout = 20;
             fakeStartConfig.annotations['beta.screwdriver.cd/timeout'] = 120;
             postConfig.json.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 20 15'
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg ' +
+                `${executor.buildTimeout} 15`
             ];
 
             return executor.start(fakeStartConfig).then(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,8 @@ const _ = require('lodash');
 
 sinon.assert.expose(assert, { prefix: '' });
 
+const DEFAULT_BUILD_TIMEOUT = 90;
+const MAX_BUILD_TIMEOUT = 120;
 const TEST_TIM_YAML = `
 metadata:
   name: {{build_id_with_prefix}}
@@ -145,6 +147,7 @@ describe('index', function () {
         executor = new Executor({
             kubernetes: {
                 buildTimeout: 12,
+                maxBuildTimeout: 220,
                 token: 'api_key2',
                 host: 'kubernetes2',
                 serviceAccount: 'foobar',
@@ -164,6 +167,7 @@ describe('index', function () {
             launchVersion: 'v1.2.3'
         });
         assert.equal(executor.buildTimeout, 12);
+        assert.equal(executor.maxBuildTimeout, 220);
         assert.equal(executor.prefix, 'beta_');
         assert.equal(executor.token, 'api_key2');
         assert.equal(executor.host, 'kubernetes2');
@@ -179,7 +183,8 @@ describe('index', function () {
     it('allow empty options', () => {
         fsMock.existsSync.returns(false);
         executor = new Executor();
-        assert.equal(executor.buildTimeout, 90);
+        assert.equal(executor.buildTimeout, DEFAULT_BUILD_TIMEOUT);
+        assert.equal(executor.maxBuildTimeout, MAX_BUILD_TIMEOUT);
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
         assert.equal(executor.token, '');
@@ -358,12 +363,10 @@ describe('index', function () {
             });
         });
 
-        it('overrides the build timeout if specified by user', () => {
-            const testTimeout = 45;
-
-            fakeStartConfig.annotations['beta.screwdriver.cd/timeout'] = testTimeout;
+        it('sets the build timeout to default build timeout if not configured by user', () => {
             postConfig.json.command = [
-                `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${testTimeout} 15`
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
+                + `${DEFAULT_BUILD_TIMEOUT} 15`
             ];
 
             return executor.start(fakeStartConfig).then(() => {
@@ -372,12 +375,25 @@ describe('index', function () {
             });
         });
 
-        it('uses cluster build timeout if user specified a higher timeout', () => {
-            executor.buildTimeout = 20;
-            fakeStartConfig.annotations['beta.screwdriver.cd/timeout'] = 120;
+        it('sets the build timeout if configured by user', () => {
+            const userTimeout = 45;
+
             postConfig.json.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg ' +
-                `${executor.buildTimeout} 15`
+                `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${userTimeout} 15`
+            ];
+            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': userTimeout };
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledOnce(requestMock);
+                assert.calledWith(requestMock, postConfig);
+            });
+        });
+
+        it('sets the timeout to maxBuildTimeout if user specified a higher timeout', () => {
+            fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 220 };
+            postConfig.json.command = [
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
+                + `${MAX_BUILD_TIMEOUT} 15`
             ];
 
             return executor.start(fakeStartConfig).then(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -358,13 +358,25 @@ describe('index', function () {
             });
         });
 
-        it('sets the build timeout', () => {
-            const testTimeout = 10800;
+        it('overrides the build timeout if specified by user', () => {
+            const testTimeout = 45;
 
             fakeStartConfig.annotations['beta.screwdriver.cd/timeout'] = testTimeout;
-
             postConfig.json.command = [
                 `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${testTimeout} 15`
+            ];
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledOnce(requestMock);
+                assert.calledWith(requestMock, postConfig);
+            });
+        });
+
+        it('uses cluster build timeout if user specified a higher timeout', () => {
+            executor.buildTimeout = 20;
+            fakeStartConfig.annotations['beta.screwdriver.cd/timeout'] = 120;
+            postConfig.json.command = [
+                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 20 15'
             ];
 
             return executor.start(fakeStartConfig).then(() => {


### PR DESCRIPTION
Allow cluster admin to configure default build timeout for the cluster

Related: screwdriver-cd/screwdriver#545