### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const _ = require('lodash');
 
 const ANNOTATE_BUILD_TIMEOUT = 'beta.screwdriver.cd/timeout';
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
-const DEFAULT_BUILD_TIMEOUT = 90;     // 90 minutes
-const MAX_BUILD_TIMEOUT = 120;        // 120 minutes
+const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
+const MAX_BUILD_TIMEOUT = 120; // 120 minutes
 const RAM_RESOURCE = 'beta.screwdriver.cd/ram';
 
 const TOLERATIONS_PATH = 'spec.tolerations';

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
 
 const ANNOTATE_BUILD_TIMEOUT = 'beta.screwdriver.cd/timeout';
 const CPU_RESOURCE = 'beta.screwdriver.cd/cpu';
-const DEFAULT_BUILD_TIMEOUT = 90;     // 90 minutes
+const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
 const RAM_RESOURCE = 'beta.screwdriver.cd/ram';
 
 const TOLERATIONS_PATH = 'spec.tolerations';
@@ -162,7 +162,7 @@ class K8sExecutor extends Executor {
         const buildTimeout = annotations[ANNOTATE_BUILD_TIMEOUT] || this.buildTimeout;
         const cpuConfig = annotations[CPU_RESOURCE];
         const CPU = (cpuConfig === 'HIGH') ? this.highCpu * 1000 : this.lowCpu * 1000; // 6000 millicpu or 2000 millicpu
-        const MEMORY = (annotations[RAM_RESOURCE] === 'HIGH') ? this.highMemory : this.lowMemory;      // 12GB or 2GB
+        const MEMORY = (annotations[RAM_RESOURCE] === 'HIGH') ? this.highMemory : this.lowMemory; // 12GB or 2GB
         const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
             build_id_with_prefix: `${this.prefix}${config.buildId}`,
             build_id: config.buildId,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "rewire": "^3.0.2",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-  image: node:6
+  image: node:8
 
 jobs:
   main:


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`

**Additional change:**

* Update ESLint, along with `eslint-config-screwdriver`, and lint all files