### PR TITLE
[2] fix: add start/stop periodic functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,6 +257,24 @@ class K8sExecutor extends Executor {
     }
 
     /**
+     * Starts a new periodic build in an executor
+     * @method _startPeriodic
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    _startPeriodic() {
+        return Promise.resolve(null);
+    }
+
+    /**
+     * Stops a new periodic build in an executor
+     * @method _stopPeriodic
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    _stopPeriodic() {
+        return Promise.resolve(null);
+    }
+
+    /**
     * Retreive stats for the executor
     * @method stats
     * @param  {Response} Object          Object containing stats for the executor

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.5",
     "request": "^2.72.0",
-    "screwdriver-executor-base": "^5.2.0",
+    "screwdriver-executor-base": "^6.1.0",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -530,6 +530,14 @@ describe('index', function () {
         });
     });
 
+    describe('periodic', () => {
+        it('resolves to null when calling periodic start',
+            () => executor.startPeriodic().then(res => assert.isNull(res)));
+
+        it('resolves to null when calling periodic stop',
+            () => executor.stopPeriodic().then(res => assert.isNull(res)));
+    });
+
     describe('setNodeSelector', () => {
         // eslint-disable-next-line no-underscore-dangle
         const setNodeSelector = index.__get__('setNodeSelector');


### PR DESCRIPTION
Resolving to `null` since it's not supported. 
We need this because models always call `_startPeriodic` for `update`

Blocked by: https://github.com/screwdriver-cd/executor-base/pull/39
Related: https://github.com/screwdriver-cd/screwdriver/issues/688