### PR TITLE
feat: Prevent K8s pods from getting API credentials

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -8,6 +8,7 @@ metadata:
     tier: builds
 spec:
   serviceAccount: {{service_account}}
+  automountServiceAccountToken: false
   restartPolicy: Never
   containers:
   - name: build


### PR DESCRIPTION
This prevents the build containers from getting access to a credential
that can be used to access the K8s API.  See [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server) for more information.