### PR TITLE
fix(1030): [2] Add to call method in executor-base to get JWT for build

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,8 +187,15 @@ class K8sExecutor extends Executor {
             ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.maxBuildTimeout)
             : this.buildTimeout;
 
+        console.log('==before exchangeTokenForBuild=====');
+        console.log(config);
+        console.log(buildTimeout);
+
         // exchange temporal JWT to build JWT
-        return this.exchangeTokenForBuild(config, buildTimeout).then(() => {
+        return this.exchangeTokenForBuild(config, buildTimeout).then((buildToken) => {
+            console.log('==after exchangeTokenForBuild=====');
+            config.token = buildToken;
+            console.log(config);
             const podTemplate = tinytim.renderFile(
                 path.resolve(__dirname, './config/pod.yaml.tim'), {
                     build_id_with_prefix: `${this.prefix}${config.buildId}`,

--- a/index.js
+++ b/index.js
@@ -187,15 +187,10 @@ class K8sExecutor extends Executor {
             ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.maxBuildTimeout)
             : this.buildTimeout;
 
-        console.log('==before exchangeTokenForBuild=====');
-        console.log(config);
-        console.log(buildTimeout);
-
         // exchange temporal JWT to build JWT
         return this.exchangeTokenForBuild(config, buildTimeout).then((buildToken) => {
-            console.log('==after exchangeTokenForBuild=====');
             config.token = buildToken;
-            console.log(config);
+
             const podTemplate = tinytim.renderFile(
                 path.resolve(__dirname, './config/pod.yaml.tim'), {
                     build_id_with_prefix: `${this.prefix}${config.buildId}`,

--- a/index.js
+++ b/index.js
@@ -187,43 +187,47 @@ class K8sExecutor extends Executor {
             ? Math.min(annotations[ANNOTATE_BUILD_TIMEOUT], this.maxBuildTimeout)
             : this.buildTimeout;
 
-        const podTemplate = tinytim.renderFile(path.resolve(__dirname, './config/pod.yaml.tim'), {
-            build_id_with_prefix: `${this.prefix}${config.buildId}`,
-            build_id: config.buildId,
-            build_timeout: buildTimeout,
-            container: config.container,
-            api_uri: this.ecosystem.api,
-            store_uri: this.ecosystem.store,
-            token: config.token,
-            launcher_version: this.launchVersion,
-            service_account: this.serviceAccount,
-            cpu: CPU,
-            memory: MEMORY
+        // exchange temporal JWT to build JWT
+        this.exchangeTokenForBuild(config, buildTimeout).then(() => {
+            const podTemplate = tinytim.renderFile(
+                path.resolve(__dirname, './config/pod.yaml.tim'), {
+                    build_id_with_prefix: `${this.prefix}${config.buildId}`,
+                    build_id: config.buildId,
+                    build_timeout: buildTimeout,
+                    container: config.container,
+                    api_uri: this.ecosystem.api,
+                    store_uri: this.ecosystem.store,
+                    token: config.token,
+                    launcher_version: this.launchVersion,
+                    service_account: this.serviceAccount,
+                    cpu: CPU,
+                    memory: MEMORY
+                });
+
+            const podConfig = yaml.safeLoad(podTemplate);
+
+            setNodeSelector(podConfig, this.nodeSelectors);
+            setPreferredNodeSelector(podConfig, this.preferredNodeSelectors);
+
+            const options = {
+                uri: this.podsUrl,
+                method: 'POST',
+                json: podConfig,
+                headers: {
+                    Authorization: `Bearer ${this.token}`
+                },
+                strictSSL: false
+            };
+
+            return this.breaker.runCommand(options)
+                .then((resp) => {
+                    if (resp.statusCode !== 201) {
+                        throw new Error(`Failed to create pod: ${JSON.stringify(resp.body)}`);
+                    }
+
+                    return null;
+                });
         });
-
-        const podConfig = yaml.safeLoad(podTemplate);
-
-        setNodeSelector(podConfig, this.nodeSelectors);
-        setPreferredNodeSelector(podConfig, this.preferredNodeSelectors);
-
-        const options = {
-            uri: this.podsUrl,
-            method: 'POST',
-            json: podConfig,
-            headers: {
-                Authorization: `Bearer ${this.token}`
-            },
-            strictSSL: false
-        };
-
-        return this.breaker.runCommand(options)
-            .then((resp) => {
-                if (resp.statusCode !== 201) {
-                    throw new Error(`Failed to create pod: ${JSON.stringify(resp.body)}`);
-                }
-
-                return null;
-            });
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ class K8sExecutor extends Executor {
             : this.buildTimeout;
 
         // exchange temporal JWT to build JWT
-        this.exchangeTokenForBuild(config, buildTimeout).then(() => {
+        return this.exchangeTokenForBuild(config, buildTimeout).then(() => {
             const podTemplate = tinytim.renderFile(
                 path.resolve(__dirname, './config/pod.yaml.tim'), {
                     build_id_with_prefix: `${this.prefix}${config.buildId}`,

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "rewire": "^3.0.2",
-    "sinon": "^1.17.6",
-    "sinon-as-promised": "^4.0.2"
+    "sinon": "^5.0.10"
   },
   "dependencies": {
     "circuit-fuses": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "rewire": "^3.0.2",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.6",
+    "sinon-as-promised": "^4.0.2"
   },
   "dependencies": {
     "circuit-fuses": "^2.1.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,8 +10,6 @@ const _ = require('lodash');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-require('sinon-as-promised');
-
 const DEFAULT_BUILD_TIMEOUT = 90;
 const MAX_BUILD_TIMEOUT = 120;
 const TEST_TIM_YAML = `

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,7 +37,7 @@ describe('index', function () {
     let fsMock;
     let executor;
     const testBuildId = 15;
-    const testToken = 'abcdefg';
+    let testToken = 'abcdefg';
     const testApiUri = 'http://api:8080';
     const testStoreUri = 'http://store:8080';
     const testContainer = 'node:4';
@@ -326,7 +326,7 @@ describe('index', function () {
                         memory: 2
                     },
                     command: [
-                        '/opt/sd/launch http://api:8080 http://store:8080 abcdefg 90 '
+                        '/opt/sd/launch http://api:8080 http://store:8080 someBuildToken 90 '
                         + '15'
                     ]
                 },
@@ -345,7 +345,11 @@ describe('index', function () {
             requestMock.yieldsAsync(null, fakeStartResponse, fakeStartResponse.body);
 
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
+        });
+
+        afterEach(() => {
+            testToken = 'abcdefg';
         });
 
         it('successfully calls start', () => {
@@ -401,7 +405,7 @@ describe('index', function () {
 
         it('sets the build timeout to default build timeout if not configured by user', () => {
             postConfig.json.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
+                '/opt/sd/launch http://api:8080 http://store:8080 someBuildToken '
                 + `${DEFAULT_BUILD_TIMEOUT} 15`
             ];
 
@@ -415,7 +419,7 @@ describe('index', function () {
             const userTimeout = 45;
 
             postConfig.json.command = [
-                `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${userTimeout} 15`
+                `/opt/sd/launch http://api:8080 http://store:8080 someBuildToken ${userTimeout} 15`
             ];
             fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': userTimeout };
 
@@ -428,7 +432,7 @@ describe('index', function () {
         it('sets the timeout to maxBuildTimeout if user specified a higher timeout', () => {
             fakeStartConfig.annotations = { 'beta.screwdriver.cd/timeout': 220 };
             postConfig.json.command = [
-                '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
+                '/opt/sd/launch http://api:8080 http://store:8080 someBuildToken '
                 + `${MAX_BUILD_TIMEOUT} 15`
             ];
 
@@ -454,7 +458,7 @@ describe('index', function () {
             });
 
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);
@@ -478,7 +482,7 @@ describe('index', function () {
             });
 
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);
@@ -505,7 +509,7 @@ describe('index', function () {
             });
 
             exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
-            exchangeTokenStub.resolves();
+            exchangeTokenStub.resolves('someBuildToken');
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,8 @@ const _ = require('lodash');
 
 sinon.assert.expose(assert, { prefix: '' });
 
+require('sinon-as-promised');
+
 const DEFAULT_BUILD_TIMEOUT = 90;
 const MAX_BUILD_TIMEOUT = 120;
 const TEST_TIM_YAML = `
@@ -308,6 +310,7 @@ describe('index', function () {
 
         let postConfig;
         let fakeStartConfig;
+        let exchangeTokenStub;
 
         beforeEach(() => {
             postConfig = {
@@ -340,6 +343,9 @@ describe('index', function () {
                 apiUri: testApiUri
             };
             requestMock.yieldsAsync(null, fakeStartResponse, fakeStartResponse.body);
+
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves();
         });
 
         it('successfully calls start', () => {
@@ -447,6 +453,9 @@ describe('index', function () {
                 }
             });
 
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves();
+
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, postConfig);
@@ -467,6 +476,9 @@ describe('index', function () {
                     preferredNodeSelectors: { key: 'value', foo: 'bar' }
                 }
             });
+
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves();
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);
@@ -491,6 +503,9 @@ describe('index', function () {
                     preferredNodeSelectors: { key: 'value', foo: 'bar' }
                 }
             });
+
+            exchangeTokenStub = sinon.stub(executor, 'exchangeTokenForBuild');
+            exchangeTokenStub.resolves();
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);


### PR DESCRIPTION
## Objective 
- When build starts in executor, call [`exchangeTokenForBuild()`](https://github.com/screwdriver-cd/executor-base/pull/42) method which is added in `executor-base` to get build JWT, and replace `config.token` to the new JWT.
- `buildTimeout` argument can be passed to this method. It will be the expires time of build JWT.

## References
- Issues: 
　https://github.com/screwdriver-cd/screwdriver/issues/998
　https://github.com/screwdriver-cd/screwdriver/issues/1030
　https://github.com/screwdriver-cd/screwdriver/issues/1075
- Related: (other PRs)
　https://github.com/screwdriver-cd/screwdriver/pull/1087
　https://github.com/screwdriver-cd/models/pull/245
　https://github.com/screwdriver-cd/executor-base/pull/42
　https://github.com/screwdriver-cd/executor-k8s/pull/84
　https://github.com/screwdriver-cd/executor-k8s-vm/pull/33
　https://github.com/screwdriver-cd/executor-docker/pull/25
　https://github.com/screwdriver-cd/executor-jenkins/pull/20

## TODO
- [x] Add unit test