### PR TITLE
BREAKING CHANGE: Use launcher script as entrypoint command

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -19,10 +19,8 @@ spec:
         cpu: {{cpu}}m
         memory: {{memory}}Gi
     command:
-    - "/opt/sd/tini"
-    - "--"
-    - "/bin/sh"
-    - "-c"
+    - "/opt/sd/launcher_entrypoint.sh"
+    args:
     # Run the launcher and logservice in the background
     # Wait for both background jobs to complete
     - |


### PR DESCRIPTION
## Context

Requires:
* screwdriver-cd/launcher#179 and the new minimum launcher version.
* A major version bump

## Objective

Use the Launcher's `launcher_entrypoint.sh` script as the new entrypoint command. 

## Reference

* Dependent Launcher PR screwdriver-cd/launcher#179
* Related issue: screwdriver-cd/screwdriver#979