### PR TITLE
feat(1114): Pass in API URI to log-service. BREAKING CHANGE: switching var names [3]

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -25,7 +25,7 @@ spec:
     # Wait for both background jobs to complete
     - |
       /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}} &
-      /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{store_uri}} --build {{build_id}} &
+      /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
       wait $(jobs -p)
     volumeMounts:
     - mountPath: /opt/sd

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "hoek": "^5.0.2",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.5",
-    "request": "^2.72.0",
-    "screwdriver-executor-base": "^6.1.0",
+    "request": "^2.87.0",
+    "screwdriver-executor-base": "^6.1.5",
     "tinytim": "^0.1.1"
   }
 }


### PR DESCRIPTION
Need to pass in API and Store urls.

Previously, we were passing in store uri like this:
```
--api-uri {{store_uri}}
```
Fixing the env var names in this PR. Also makes it more consistent with launcher.
```
--api-uri {{api_uri}} --store-uri {{store_uri}}
```

Related to https://github.com/screwdriver-cd/screwdriver/issues/1114