### PR TITLE
feat(1167): [5][small] Use wrapper script

### DIFF
--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -24,9 +24,10 @@ spec:
     # Run the launcher and logservice in the background
     # Wait for both background jobs to complete
     - |
-      /opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}} &
+      SD_TOKEN=`/opt/sd/launch --fetch-flag --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}}` &&
+      (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}} &
       /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
-      wait $(jobs -p)
+      wait $(jobs -p))
     volumeMounts:
     - mountPath: /opt/sd
       name: screwdriver

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -23,7 +23,7 @@ spec:
     args:
     # Run the wrapper script
     - |
-      /opt/sd/run.sh "{{token}}" {{api_uri}} {{store_uri}} {{build_timeout}} {{build_id}}
+      /opt/sd/run.sh "{{token}}" "{{api_uri}}" "{{store_uri}}" "{{build_timeout}}" "{{build_id}}"
     volumeMounts:
     - mountPath: /opt/sd
       name: screwdriver

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -24,7 +24,7 @@ spec:
     # Run the launcher and logservice in the background
     # Wait for both background jobs to complete
     - |
-      SD_TOKEN=`/opt/sd/launch --fetch-flag --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}}` &&
+      SD_TOKEN=`/opt/sd/launch --only-fetch-token --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}}` &&
       (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}} &
       /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
       wait $(jobs -p))

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -24,7 +24,7 @@ spec:
     # Run the launcher and logservice in the background
     # Wait for both background jobs to complete
     - |
-      SD_TOKEN=`/opt/sd/launch --only-fetch-token --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}}` &&
+      SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "{{token}}" --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}}` &&
       (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}} &
       /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
       wait $(jobs -p))
@@ -35,9 +35,6 @@ spec:
       name: workspace
     - mountPath: /hab
       name: habitat
-    env:
-    - name: SD_TOKEN
-      value: "{{token}}"
   initContainers:
   - name: launcher
     image: screwdrivercd/launcher:{{launcher_version}}

--- a/config/pod.yaml.tim
+++ b/config/pod.yaml.tim
@@ -21,13 +21,9 @@ spec:
     command:
     - "/opt/sd/launcher_entrypoint.sh"
     args:
-    # Run the launcher and logservice in the background
-    # Wait for both background jobs to complete
+    # Run the wrapper script
     - |
-      SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "{{token}}" --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}}` &&
-      (/opt/sd/launch --api-uri {{api_uri}} --store-uri {{store_uri}} --emitter /opt/sd/emitter --build-timeout {{build_timeout}} {{build_id}} &
-      /opt/sd/logservice --emitter /opt/sd/emitter --api-uri {{api_uri}} --store-uri {{store_uri}} --build {{build_id}} &
-      wait $(jobs -p))
+      /opt/sd/run.sh "{{token}}" {{api_uri}} {{store_uri}} {{build_timeout}} {{build_id}}
     volumeMounts:
     - mountPath: /opt/sd
       name: screwdriver


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To fetch build token in actual build execution, we fixed to exchange temporal token to build token in launcher process. 
However, also log-service uses token which is passed by `executor-*`.
To pass fetched build token to log-service and launcher, add the flag to launcher which only fetch token in launcher process, and use this flag to set fetched token before launcher and log-service processes start.
Detail: https://github.com/screwdriver-cd/screwdriver/issues/1167#issuecomment-409441739

Launcher passes wrapper script to run build. Therefore, each executor uses this script.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Use wrapper script to run build.

## References
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
issue comment: https://github.com/screwdriver-cd/screwdriver/issues/1167#issuecomment-409441739

PR:
launcher: https://github.com/screwdriver-cd/launcher/pull/203
hyperctl-image: https://github.com/screwdriver-cd/hyperctl-image/pull/24
executor-docker: https://github.com/screwdriver-cd/executor-docker/pull/28
executor-jenkins: https://github.com/screwdriver-cd/executor-jenkins/pull/24