### PR TITLE
fix(818): set k8s annotations if configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc_output

--- a/index.js
+++ b/index.js
@@ -22,6 +22,21 @@ const AFFINITY_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
 const AFFINITY_PREFERRED_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
     'preferredDuringSchedulingIgnoredDuringExecution';
 const PREFERRED_WEIGHT = 100;
+const ANNOTATIONS_PATH = 'metadata.annotations';
+
+/**
+ * Parses annotations config and update intended annotations
+ * @param {Object} podConfig      k8s pod config
+ * @param {Object} annotations    key-value pairs of annotations
+ */
+function setAnnotations(podConfig, annotations) {
+    if (!annotations || typeof annotations !== 'object' ||
+        Object.keys(annotations).length === 0) {
+        return;
+    }
+
+    _.set(podConfig, ANNOTATIONS_PATH, annotations);
+}
 
 /**
  * Parses nodeSelector config and update intended nodeSelector in tolerations
@@ -153,6 +168,7 @@ class K8sExecutor extends Executor {
         this.microMemory = hoek.reach(options, 'kubernetes.resources.memory.micro', { default: 1 });
         this.nodeSelectors = hoek.reach(options, 'kubernetes.nodeSelectors');
         this.preferredNodeSelectors = hoek.reach(options, 'kubernetes.preferredNodeSelectors');
+        this.annotations = hoek.reach(options, 'kubernetes.annotations');
     }
 
     /**
@@ -206,6 +222,7 @@ class K8sExecutor extends Executor {
 
         setNodeSelector(podConfig, this.nodeSelectors);
         setPreferredNodeSelector(podConfig, this.preferredNodeSelectors);
+        setAnnotations(podConfig, this.annotations);
 
         const options = {
             uri: this.podsUrl,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,6 +88,12 @@ describe('index', function () {
             }
         }
     };
+    const testAnnotations = {
+        annotations: {
+            key: 'value',
+            key2: 'value2'
+        }
+    };
 
     before(() => {
         mockery.enable({
@@ -425,6 +431,27 @@ describe('index', function () {
                 '/opt/sd/launch http://api:8080 http://store:8080 abcdefg '
                 + `${MAX_BUILD_TIMEOUT} 15`
             ];
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledOnce(requestMock);
+                assert.calledWith(requestMock, postConfig);
+            });
+        });
+
+        it('sets annotations with appropriate annotations config', () => {
+            postConfig.json.metadata.annotations = testAnnotations.annotations;
+
+            executor = new Executor({
+                ecosystem: {
+                    api: testApiUri,
+                    store: testStoreUri
+                },
+                fusebox: { retry: { minTimeout: 1 } },
+                prefix: 'beta_',
+                kubernetes: {
+                    annotations: { key: 'value', key2: 'value2' }
+                }
+            });
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledOnce(requestMock);


### PR DESCRIPTION
Allow cluster admin to inject annotations to build pod yaml.

example annotations:
https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

Related to: https://github.com/screwdriver-cd/screwdriver/issues/818