### PR TITLE
fix: Change setNodeSelector to use a single nodeSelectorTerm

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const RETRYDELAY = 3000;
 
 const TOLERATIONS_PATH = 'spec.tolerations';
 const AFFINITY_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
-    'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms';
+    'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions';
 const AFFINITY_PREFERRED_NODE_SELECTOR_PATH = 'spec.affinity.nodeAffinity.' +
     'preferredDuringSchedulingIgnoredDuringExecution';
 const PREFERRED_WEIGHT = 100;
@@ -64,11 +64,9 @@ function setNodeSelector(podConfig, nodeSelectors) {
             operator: 'Equal'
         });
         nodeAffinitySelectors.push({
-            matchExpressions: [{
-                key,
-                operator: 'In',
-                values: [nodeSelectors[key]]
-            }]
+            key,
+            operator: 'In',
+            values: [nodeSelectors[key]]
         });
     });
 


### PR DESCRIPTION
## Context
Our current implementation of `setNodeSelector` appends multiple `nodeSelectorTerms` to the spec. This leads to an `OR` scheduling behavior where the pod can be scheduled on any node that is labled with any of the `nodeSelectors`. 

I believe we desire an `AND` scheduling behavior where the pod can be scheduled on any node that is labled with ALL of the `nodeSelectors`. This PR changes the implementation of `setNodeSelector` to honor this `AND` behavior of scheduling.

## Objective
Update `setNodeSelector` to append multiple keys to a single `nodeSelectorTerm`

## References
https://github.com/screwdriver-cd/screwdriver/issues/757
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
https://github.com/kubernetes/kubernetes/issues/44349
https://github.com/screwdriver-cd/executor-k8s-vm/pull/43