### PR TITLE
fix(1261): pod delete immediately when build has stopped.

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,6 +339,9 @@ class K8sExecutor extends Executor {
         const options = {
             uri: this.podsUrl,
             method: 'DELETE',
+            json: {
+                gracePeriodSeconds: 0
+            },
             qs: {
                 labelSelector: `sdbuild=${this.prefix}${config.buildId}`
             },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -251,6 +251,9 @@ describe('index', function () {
         const deleteConfig = {
             uri: podsUrl,
             method: 'DELETE',
+            json: {
+                gracePeriodSeconds: 0
+            },
             qs: {
                 labelSelector: `sdbuild=beta_${testBuildId}`
             },


### PR DESCRIPTION
# Objective
A build didn't stop even if pushing stop button in the Completed step in a short time(roughly within 30 sec).
I modified to the build stops certainly after pushing stop button.

# References
- Issues:
https://github.com/screwdriver-cd/screwdriver/issues/1261
- kubernetes-api Documents
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/