### PR TITLE
fix: [1][small] Send image pull error to queue-worker

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -676,6 +676,38 @@ describe('index', function () {
             });
         });
 
+        it('returns error when pod waiting reason is ErrImagePull', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'ErrImagePull',
+                                        message: 'can not pull image'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(
+                null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(() => {
+                throw new Error('did not fail');
+            }, (err) => {
+                assert.equal(err.message, returnMessage);
+            });
+        });
+
         it('update build status message when pod status is pending', () => {
             const returnResponse = {
                 statusCode: 200,


### PR DESCRIPTION
## Context
Users can not get information why the build does not start on image pull error.

## Objective
Shows the image pull error for users. Like below, like k8s-vm
<img width="394" alt="2018-10-31 17 13 21" src="https://user-images.githubusercontent.com/32473622/47780259-63fc7380-dd3e-11e8-891a-be985ca1715f.png">

This pr send the failure message to the queue-worker.

## RelatedPRs
https://github.com/screwdriver-cd/queue-worker/pull/105
https://github.com/screwdriver-cd/executor-k8s/pull/98