### PR TITLE
fix: build is not in start params

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,14 +225,13 @@ class K8sExecutor extends Executor {
      * Starts a k8s build
      * @method start
      * @param  {Object}   config            A configuration object
-     * @param  {Object}   [config.build]    Build object
      * @param  {Integer}  config.buildId    ID for the build
      * @param  {String}   config.container  Container for the build to run in
      * @param  {String}   config.token      JWT for the Build
      * @return {Promise}
      */
     _start(config) {
-        const { build, buildId, container, token } = config;
+        const { buildId, container, token } = config;
         const random = randomstring.generate({
             length: 5,
             charset: 'alphanumeric',
@@ -341,11 +340,10 @@ class K8sExecutor extends Executor {
                     token
                 };
 
-                // for backward compatibility
-                if (build && build.stats && resp.body.spec && resp.body.spec.nodeName) {
-                    // don't want to override other fields in stats
-                    build.stats.hostname = resp.body.spec.nodeName;
-                    updateConfig.stats = build.stats;
+                if (resp.body.spec && resp.body.spec.nodeName) {
+                    updateConfig.stats = {
+                        hostname: resp.body.spec.nodeName
+                    };
                 }
 
                 if (status === 'pending') {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "randomstring": "^1.1.5",
     "request": "^2.87.0",
     "requestretry": "^2.0.2",
-    "screwdriver-executor-base": "^6.2.2",
+    "screwdriver-executor-base": "^6.3.0",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -322,15 +322,8 @@ describe('index', function () {
         let fakeStartResponse;
         let fakeGetResponse;
         let fakePutResponse;
-        let buildMock;
 
         beforeEach(() => {
-            buildMock = {
-                id: testBuildId,
-                stats: {
-                    queueEnterTime: '2018-12-13T22:35:16.552Z'
-                }
-            };
             postConfig = {
                 uri: podsUrl,
                 method: 'POST',
@@ -424,10 +417,8 @@ describe('index', function () {
         });
 
         it('successfully calls start and update hostname', () => {
-            fakeStartConfig.build = buildMock;
             putConfig.body.stats = {
-                hostname: 'node1.my.k8s.cluster.com',
-                queueEnterTime: '2018-12-13T22:35:16.552Z'
+                hostname: 'node1.my.k8s.cluster.com'
             };
 
             return executor.start(fakeStartConfig).then(() => {
@@ -618,6 +609,7 @@ describe('index', function () {
 
         it('update build status message when pod status is pending', () => {
             fakeGetResponse.body.status.phase = 'pending';
+            fakeGetResponse.body.spec = {};
             putConfig.body.statusMessage = 'Waiting for resources to be available.';
 
             return executor.start(fakeStartConfig).then(() => {


### PR DESCRIPTION
A couple issues to previous implementation:
- executor-k8s and executor-k8s-vm actually gets the params from redis. So `build` is not there
- We cannot store `build` in redis since its value might change, and `stop` needs exact params to delete from queue

Solution: blindly updates hostname here. The API will handle the logic to merge/update it. 

Related: 
https://github.com/screwdriver-cd/screwdriver/issues/1270
https://github.com/screwdriver-cd/screwdriver/pull/1423