### PR TITLE
fix(1403): Remove graceperiod settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,9 +368,6 @@ class K8sExecutor extends Executor {
         const options = {
             uri: this.podsUrl,
             method: 'DELETE',
-            json: {
-                gracePeriodSeconds: 0
-            },
             qs: {
                 labelSelector: `sdbuild=${this.prefix}${config.buildId}`
             },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -251,9 +251,6 @@ describe('index', function () {
         const deleteConfig = {
             uri: podsUrl,
             method: 'DELETE',
-            json: {
-                gracePeriodSeconds: 0
-            },
             qs: {
                 labelSelector: `sdbuild=beta_${testBuildId}`
             },


### PR DESCRIPTION
## Objective
We added `gracePeriodSeconds: 0` option to delete pod immediately.
Now, we don't have to use this option because SIGTERM processing is done correctly https://github.com/screwdriver-cd/launcher/pull/228#pullrequestreview-180903853. 
Therefore, I remove `gracePeriodSeconds: 0`option and use default settings.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1261
https://github.com/screwdriver-cd/screwdriver/issues/1403