### PR TITLE
Fix: Fix retry strategy for nonexistent image

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,8 +193,8 @@ class K8sExecutor extends Executor {
             const waitingReason = hoek.reach(body, CONTAINER_WAITING_REASON_PATH);
             const status = hoek.reach(body, 'status.phase');
 
-            return err || !status || (status.toLowerCase() === 'pending'
-                && waitingReason !== 'ErrImagePull');
+            return err || !status || (status.toLowerCase() === 'pending' &&
+                waitingReason !== 'ErrImagePull' && waitingReason !== 'ImagePullBackOff');
         };
     }
 
@@ -376,7 +376,7 @@ class K8sExecutor extends Executor {
             .then((res) => {
                 const waitingReason = hoek.reach(res.body, CONTAINER_WAITING_REASON_PATH);
 
-                if (waitingReason === 'ErrImagePull') {
+                if (waitingReason === 'ErrImagePull' || waitingReason === 'ImagePullBackOff') {
                     throw new Error('Build failed to start. Please check if your image is valid.');
                 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -714,6 +714,38 @@ describe('index', function () {
             });
         });
 
+        it('returns error when pod waiting reason is ImagePullBackOff', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'ImagePullBackOff',
+                                        message: 'can not pull image'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(
+                null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(() => {
+                throw new Error('did not fail');
+            }, (err) => {
+                assert.equal(err.message, returnMessage);
+            });
+        });
+
         it('sets error when pod status is failed', () => {
             const returnResponse = {
                 statusCode: 200,


### PR DESCRIPTION
## Context
Currently k8s executor abort a build if it uses nonexistent image. This process is done by checking if `state.waiting.reason` is "ErrImagePull" or not. But k8s change the reason after a while, to "ImagePullBackOff", so the build will remain for a long time.

## Objective
* Add checks whether `reason` is "ImagePullBackOff" 

```
2014064-765x5                          0/1       ImagePullBackOff    0          2d
2014069-36855                          0/1       ErrImagePull        0          2d
```