### PR TITLE
feat: Docker in docker as on option for executor k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .*.swp
 .nyc_output
 package-lock.json
+.idea/

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -18,6 +18,11 @@ spec:
       limits:
         cpu: {{cpu}}m
         memory: {{memory}}Gi
+    {{#if docker.enabled}}
+    env:
+      - name: DOCKER_HOST
+        value: tcp://localhost:2375
+    {{/if}}
     command:
     - "/opt/sd/launcher_entrypoint.sh"
     args:
@@ -31,6 +36,20 @@ spec:
       name: workspace
     - mountPath: /hab
       name: habitat
+  {{#if docker.enabled}}
+  - name: dind
+    image: docker:18.05-dind
+    resources:
+      limits:
+        cpu: {{docker.cpu }}m
+        memory: {{docker.memory }}Gi
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - name: dind-storage
+        mountPath: /var/lib/docker
+  {{/if}}
+
   initContainers:
   - name: launcher
     image: {{launcher_image}}
@@ -47,3 +66,7 @@ spec:
       emptyDir: {}
     - name: workspace
       emptyDir: {}
+    {{#if docker.enabled}}
+    - name: dind-storage
+      emptyDir: {}
+    {{/if}}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "request": "^2.88.0",
     "requestretry": "^2.0.2",
     "screwdriver-executor-base": "^7.0.0",
+    "handlebars": "^4.1.0",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -117,7 +117,7 @@ describe('index', function () {
 
         fsMock.readFileSync.withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token')
             .returns('api_key');
-        fsMock.readFileSync.withArgs(sinon.match(/config\/pod.yaml.tim/))
+        fsMock.readFileSync.withArgs(sinon.match(/config\/pod.yaml.hbs/))
             .returns(TEST_TIM_YAML);
 
         mockery.registerMock('fs', fsMock);


### PR DESCRIPTION
added annotations: 
    `screwdriver.cd/dockerEnabled: true` (if not present or disabled, no additional docker in docker container will be created) 
    `screwdriver.cd/dockerCpu: LOW` (same values as cpu) 
    `screwdriver.cd/dockerRam: LOW` (same values as ram)

1. had to switch out tinytim for handlebars since tinytim on node doesn't support conditional templating. 

2. this will create a docker-in-docker container along side your build container which enable you to run in docker build / run from within the executor_k8s pod.