### PR TITLE
fix(1678): [2] add configurable retryDelay and maxAttempts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash": "^4.17.5",
     "randomstring": "^1.1.5",
     "request": "^2.88.0",
-    "requestretry": "^2.0.2",
+    "requestretry": "^4.0.0",
     "screwdriver-executor-base": "^7.1.0",
     "handlebars": "^4.1.0",
     "tinytim": "^0.1.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,6 +97,18 @@ describe('index', function () {
             key2: 'value2'
         }
     };
+    const executorOptions = {
+        ecosystem: {
+            api: testApiUri,
+            store: testStoreUri
+        },
+        kubernetes: {
+            nodeSelectors: {},
+            preferredNodeSelectors: {}
+        },
+        fusebox: { retry: { minTimeout: 1 } },
+        prefix: 'beta_'
+    };
 
     before(() => {
         mockery.enable({
@@ -127,18 +139,7 @@ describe('index', function () {
         Executor = require('../index');
         /* eslint-enable global-require */
 
-        executor = new Executor({
-            ecosystem: {
-                api: testApiUri,
-                store: testStoreUri
-            },
-            kubernetes: {
-                nodeSelectors: {},
-                preferredNodeSelectors: {}
-            },
-            fusebox: { retry: { minTimeout: 1 } },
-            prefix: 'beta_'
-        });
+        executor = new Executor(executorOptions);
     });
 
     afterEach(() => {
@@ -521,20 +522,14 @@ describe('index', function () {
         });
 
         it('sets annotations with appropriate annotations config', () => {
-            postConfig.json.metadata.annotations = testAnnotations.annotations;
-
-            executor = new Executor({
-                ecosystem: {
-                    api: testApiUri,
-                    store: testStoreUri
-                },
-                fusebox: { retry: { minTimeout: 1 } },
-                prefix: 'beta_',
+            const options = _.assign({}, executorOptions, {
                 kubernetes: {
                     annotations: { key: 'value', key2: 'value2' }
                 }
             });
 
+            executor = new Executor(options);
+            postConfig.json.metadata.annotations = testAnnotations.annotations;
             getConfig.retryStrategy = executor.scheduleStatusRetryStrategy;
 
             return executor.start(fakeStartConfig).then(() => {
@@ -544,20 +539,14 @@ describe('index', function () {
         });
 
         it('sets tolerations and node affinity with appropriate node config', () => {
-            postConfig.json.spec = testSpec;
-
-            executor = new Executor({
-                ecosystem: {
-                    api: testApiUri,
-                    store: testStoreUri
-                },
-                fusebox: { retry: { minTimeout: 1 } },
-                prefix: 'beta_',
+            const options = _.assign({}, executorOptions, {
                 kubernetes: {
                     nodeSelectors: { key: 'value' }
                 }
             });
 
+            executor = new Executor(options);
+            postConfig.json.spec = testSpec;
             getConfig.retryStrategy = executor.scheduleStatusRetryStrategy;
 
             return executor.start(fakeStartConfig).then(() => {
@@ -567,20 +556,14 @@ describe('index', function () {
         });
 
         it('sets preferred node affinity with appropriate node config', () => {
-            postConfig.json.spec = testPreferredSpec;
-
-            executor = new Executor({
-                ecosystem: {
-                    api: testApiUri,
-                    store: testStoreUri
-                },
-                fusebox: { retry: { minTimeout: 1 } },
-                prefix: 'beta_',
+            const options = _.assign({}, executorOptions, {
                 kubernetes: {
                     preferredNodeSelectors: { key: 'value', foo: 'bar' }
                 }
             });
 
+            executor = new Executor(options);
+            postConfig.json.spec = testPreferredSpec;
             getConfig.retryStrategy = executor.scheduleStatusRetryStrategy;
 
             return executor.start(fakeStartConfig).then(() => {
@@ -591,22 +574,15 @@ describe('index', function () {
 
         it('sets node affinity and preferred node affinity', () => {
             const spec = _.merge({}, testSpec, testPreferredSpec);
-
-            postConfig.json.spec = spec;
-
-            executor = new Executor({
-                ecosystem: {
-                    api: testApiUri,
-                    store: testStoreUri
-                },
-                fusebox: { retry: { minTimeout: 1 } },
-                prefix: 'beta_',
+            const options = _.assign({}, executorOptions, {
                 kubernetes: {
                     nodeSelectors: { key: 'value' },
                     preferredNodeSelectors: { key: 'value', foo: 'bar' }
                 }
             });
 
+            executor = new Executor(options);
+            postConfig.json.spec = spec;
             getConfig.retryStrategy = executor.scheduleStatusRetryStrategy;
 
             return executor.start(fakeStartConfig).then(() => {
@@ -788,24 +764,15 @@ describe('index', function () {
             });
         });
 
-        it('configures retryDelay and maxAttempts', () => {
-            executor = new Executor({
-                ecosystem: {
-                    api: testApiUri,
-                    store: testStoreUri
-                },
-                kubernetes: {
-                    nodeSelectors: {},
-                    preferredNodeSelectors: {}
-                },
-                fusebox: { retry: { minTimeout: 1 } },
-                prefix: 'beta_',
+        it('sets retryDelay and maxAttempts', () => {
+            const options = _.assign({}, executorOptions, {
                 requestretry: {
                     maxAttempts: 1,
                     retryDelay: 1000
                 }
             });
 
+            executor = new Executor(options);
             getConfig.retryDelay = 1000;
             getConfig.maxAttempts = 1;
             getConfig.retryStrategy = executor.scheduleStatusRetryStrategy;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -787,6 +787,34 @@ describe('index', function () {
                 assert.equal(err.message, returnMessage);
             });
         });
+
+        it('configures retryDelay and maxAttempts', () => {
+            executor = new Executor({
+                ecosystem: {
+                    api: testApiUri,
+                    store: testStoreUri
+                },
+                kubernetes: {
+                    nodeSelectors: {},
+                    preferredNodeSelectors: {}
+                },
+                fusebox: { retry: { minTimeout: 1 } },
+                prefix: 'beta_',
+                requestretry: {
+                    maxAttempts: 1,
+                    retryDelay: 1000
+                }
+            });
+
+            getConfig.retryDelay = 1000;
+            getConfig.maxAttempts = 1;
+            getConfig.retryStrategy = executor.scheduleStatusRetryStrategy;
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
     });
 
     describe('periodic', () => {


### PR DESCRIPTION
## Context

[An error message](https://github.com/screwdriver-cd/executor-k8s/blob/2d52738caff561335b2aaa5c2620e4818b03c05b/index.js#L407-L409
) was not shown on UI and a build status was not changed even if users use invalid image.

This might be caused by pod's waiting reason is `PodInitializing` after [these retrying](https://github.com/screwdriver-cd/executor-k8s/blob/2d52738caff561335b2aaa5c2620e4818b03c05b/index.js#L391-L400).

## Objective
To prevent this problem, `MAXATTEMPTS` and `RETRYDELAY` should be configurable.
## References
https://github.com/screwdriver-cd/screwdriver/issues/1678

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
