### PR TITLE
feat(818): Enable Privileged mode for kata containers

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -14,6 +14,8 @@ spec:
   - name: build
     image: {{container}}
     imagePullPolicy: Always
+    securityContext:
+      privileged: true
     resources:
       limits:
         cpu: {{cpu}}m


### PR DESCRIPTION
## Context

Enable kata containers to run in privileged mode 


## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
