### PR TITLE
feat(818): Security Context privileged mode configurable via a flag by admin

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -15,7 +15,7 @@ spec:
     image: {{container}}
     imagePullPolicy: Always
     securityContext:
-      privileged: true
+      privileged: {{privileged}}
     resources:
       limits:
         cpu: {{cpu}}m

--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ class K8sExecutor extends Executor {
      * @param  {String} [options.kubernetes.resources.disk.space]          Value for disk space label (e.g.: screwdriver.cd/disk)
      * @param  {String} [options.kubernetes.resources.disk.speed]          Value for disk speed label (e.g.: screwdriver.cd/diskSpeed)
      * @param  {Boolean} [options.kubernetes.dockerFeatureEnabled=false]   Whether to enable docker in docker on the executor k8 container
+     * @param  {Boolean} [options.kubernetes.privileged=false]             Privileged mode, default restricted, set to true for DIND use-case
      * @param  {Object} [options.kubernetes.nodeSelectors]                 Object representing node label-value pairs
      * @param  {String} [options.launchVersion=stable]                     Launcher container version to use
      * @param  {String} [options.prefix='']                                 Prefix for job name
@@ -216,6 +217,7 @@ class K8sExecutor extends Executor {
         this.dockerFeatureEnabled = hoek.reach(options, 'kubernetes.dockerFeatureEnabled',
             { default: false });
         this.annotations = hoek.reach(options, 'kubernetes.annotations');
+        this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });
         this.scheduleStatusRetryStrategy = (err, response, body) => {
             const conditions = hoek.reach(body, 'status.conditions');
             let scheduled = false;
@@ -370,6 +372,7 @@ class K8sExecutor extends Executor {
             cpu,
             memory,
             pod_name: `${this.prefix}${buildId}-${random}`,
+            privileged: this.privileged,
             build_id_with_prefix: `${this.prefix}${buildId}`,
             build_id: buildId,
             job_id: jobId,


### PR DESCRIPTION
## Context

By default, k8s pod runs in privileged mode.

## Objective

By default, k8s pod runs in secured mode and privileged mode is enabled via a flag by admin.

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
