### PR TITLE
feat: change service account config

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -7,8 +7,8 @@ metadata:
     app: screwdriver
     tier: builds
 spec:
-  serviceAccount: {{service_account}}
-  automountServiceAccountToken: false
+  serviceAccountName: {{service_account}}
+  automountServiceAccountToken: {{automount_service_account_token}}
   restartPolicy: Never
   containers:
   - name: build

--- a/index.js
+++ b/index.js
@@ -127,45 +127,46 @@ class K8sExecutor extends Executor {
     /**
      * Constructor
      * @method constructor
-     * @param  {Object} options                                            Configuration options
-     * @param  {Object} options.ecosystem                                  Screwdriver Ecosystem
-     * @param  {Object} options.ecosystem.api                              Routable URI to Screwdriver API
-     * @param  {Object} [options.ecosystem.pushgatewayUrl]                 Pushgateway URL for Prometheus
-     * @param  {Object} options.ecosystem.store                            Routable URI to Screwdriver Store
-     * @param  {Object} options.ecosystem.ui                               Routable URI to Screwdriver UI
-     * @param  {Object} options.kubernetes                                 Kubernetes configuration
-     * @param  {String} [options.kubernetes.token]                         API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
-     * @param  {String} [options.kubernetes.host=kubernetes.default]       Kubernetes hostname
-     * @param  {Number} [options.kubernetes.jobsNamespace=default]         Pods namespace for Screwdriver Jobs
-     * @param  {String} [options.kubernetes.baseImage]                     Base image for the pod
-     * @param  {Number} [options.kubernetes.buildTimeout=90]               Number of minutes to allow a build to run before considering it is timed out
-     * @param  {Number} [options.kubernetes.maxBuildTimeout=120]           Max timeout user can configure up to
-     * @param  {String} [options.kubernetes.serviceAccount=default]        Service Account for builds
-     * @param  {String} [options.kubernetes.resources.cpu.max=12]          Upper bound for custom CPU value (in cores)
-     * @param  {String} [options.kubernetes.resources.cpu.turbo=12]        Value for TURBO CPU (in cores)
-     * @param  {String} [options.kubernetes.resources.cpu.high=6]          Value for HIGH CPU (in cores)
-     * @param  {Number} [options.kubernetes.resources.cpu.low=2]           Value for LOW CPU (in cores)
-     * @param  {Number} [options.kubernetes.resources.cpu.micro=0.5]       Value for MICRO CPU (in cores)
-     * @param  {Number} [options.kubernetes.resources.memory.turbo=16]     Value for TURBO memory (in GB)
-     * @param  {Number} [options.kubernetes.resources.memory.high=12]      Value for HIGH memory (in GB)
-     * @param  {Number} [options.kubernetes.resources.memory.low=2]        Value for LOW memory (in GB)
-     * @param  {Number} [options.kubernetes.resources.memory.micro=1]      Value for MICRO memory (in GB)
-     * @param  {String} [options.kubernetes.resources.disk.space]          Value for disk space label (e.g.: screwdriver.cd/disk)
-     * @param  {String} [options.kubernetes.resources.disk.speed]          Value for disk speed label (e.g.: screwdriver.cd/diskSpeed)
-     * @param  {Boolean} [options.kubernetes.dockerFeatureEnabled=false]   Whether to enable docker in docker on the executor k8 container
-     * @param  {Boolean} [options.kubernetes.privileged=false]             Privileged mode, default restricted, set to true for DIND use-case
-     * @param  {Object} [options.kubernetes.nodeSelectors]                 Object representing node label-value pairs
-     * @param  {String} [options.launchVersion=stable]                     Launcher container version to use
-     * @param  {String} [options.prefix='']                                 Prefix for job name
-     * @param  {String} [options.fusebox]                                  Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
-     * @param  {Object} [options.requestretry]                             Options for the requestretry (https://github.com/FGRibreau/node-request-retry)
-     * @param  {Number} [options.requestretry.retryDelay]                  Value for retryDelay option of the requestretry
-     * @param  {Number} [options.requestretry.maxAttempts]                 Value for maxAttempts option of the requestretry
-     * @param  {String} [options.ecosystem.cache.strategy='s3']            Value for build cache - s3, disk
-     * @param  {String} [options.ecosystem.cache.path='']                  Value for build cache path if options.cache.strategy is disk
-     * @param  {String} [options.ecosystem.cache.compress=false]           Value for build cache compress - true / false; used only when cache.strategy is disk
-     * @param  {String} [options.ecosystem.cache.md5check=false]           Value for build cache md5check - true / false; used only when cache.strategy is disk
-     * @param  {String} [options.ecosystem.cache.max_size_mb=0]            Value for build cache max size in mb; used only when cache.strategy is disk
+     * @param  {Object}  options                                                 Configuration options
+     * @param  {Object}  options.ecosystem                                       Screwdriver Ecosystem
+     * @param  {Object}  options.ecosystem.api                                   Routable URI to Screwdriver API
+     * @param  {Object}  [options.ecosystem.pushgatewayUrl]                      Pushgateway URL for Prometheus
+     * @param  {Object}  options.ecosystem.store                                 Routable URI to Screwdriver Store
+     * @param  {Object}  options.ecosystem.ui                                    Routable URI to Screwdriver UI
+     * @param  {Object}  options.kubernetes                                      Kubernetes configuration
+     * @param  {String}  [options.kubernetes.token]                              API Token (loaded from /var/run/secrets/kubernetes.io/serviceaccount/token if not provided)
+     * @param  {String}  [options.kubernetes.host=kubernetes.default]            Kubernetes hostname
+     * @param  {Number}  [options.kubernetes.jobsNamespace=default]              Pods namespace for Screwdriver Jobs
+     * @param  {String}  [options.kubernetes.baseImage]                          Base image for the pod
+     * @param  {Number}  [options.kubernetes.buildTimeout=90]                    Number of minutes to allow a build to run before considering it is timed out
+     * @param  {Number}  [options.kubernetes.maxBuildTimeout=120]                Max timeout user can configure up to
+     * @param  {String}  [options.kubernetes.serviceAccount=default]             Service Account for builds
+     * @param  {String}  [options.kubernetes.resources.cpu.max=12]               Upper bound for custom CPU value (in cores)
+     * @param  {String}  [options.kubernetes.resources.cpu.turbo=12]             Value for TURBO CPU (in cores)
+     * @param  {String}  [options.kubernetes.resources.cpu.high=6]               Value for HIGH CPU (in cores)
+     * @param  {Number}  [options.kubernetes.resources.cpu.low=2]                Value for LOW CPU (in cores)
+     * @param  {Number}  [options.kubernetes.resources.cpu.micro=0.5]            Value for MICRO CPU (in cores)
+     * @param  {Number}  [options.kubernetes.resources.memory.turbo=16]          Value for TURBO memory (in GB)
+     * @param  {Number}  [options.kubernetes.resources.memory.high=12]           Value for HIGH memory (in GB)
+     * @param  {Number}  [options.kubernetes.resources.memory.low=2]             Value for LOW memory (in GB)
+     * @param  {Number}  [options.kubernetes.resources.memory.micro=1]           Value for MICRO memory (in GB)
+     * @param  {String}  [options.kubernetes.resources.disk.space]               Value for disk space label (e.g.: screwdriver.cd/disk)
+     * @param  {String}  [options.kubernetes.resources.disk.speed]               Value for disk speed label (e.g.: screwdriver.cd/diskSpeed)
+     * @param  {Boolean} [options.kubernetes.dockerFeatureEnabled=false]         Whether to enable docker in docker on the executor k8 container
+     * @param  {Boolean} [options.kubernetes.privileged=false]                   Privileged mode, default restricted, set to true for DIND use-case
+     * @param  {Boolean} [options.kubernetes.automountServiceAccountToken=false] opt-in/out for service account token automount
+     * @param  {Object}  [options.kubernetes.nodeSelectors]                      Object representing node label-value pairs
+     * @param  {String}  [options.launchVersion=stable]                          Launcher container version to use
+     * @param  {String}  [options.prefix='']                                     Prefix for job name
+     * @param  {String}  [options.fusebox]                                       Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
+     * @param  {Object}  [options.requestretry]                                  Options for the requestretry (https://github.com/FGRibreau/node-request-retry)
+     * @param  {Number}  [options.requestretry.retryDelay]                       Value for retryDelay option of the requestretry
+     * @param  {Number}  [options.requestretry.maxAttempts]                      Value for maxAttempts option of the requestretry
+     * @param  {String}  [options.ecosystem.cache.strategy='s3']                 Value for build cache - s3, disk
+     * @param  {String}  [options.ecosystem.cache.path='']                       Value for build cache path if options.cache.strategy is disk
+     * @param  {String}  [options.ecosystem.cache.compress=false]                Value for build cache compress - true / false; used only when cache.strategy is disk
+     * @param  {String}  [options.ecosystem.cache.md5check=false]                Value for build cache md5check - true / false; used only when cache.strategy is disk
+     * @param  {String}  [options.ecosystem.cache.max_size_mb=0]                 Value for build cache max size in mb; used only when cache.strategy is disk
      */
     constructor(options = {}) {
         super();
@@ -189,6 +190,8 @@ class K8sExecutor extends Executor {
         this.buildTimeout = hoek.reach(options, 'kubernetes.buildTimeout') || DEFAULT_BUILD_TIMEOUT;
         this.maxBuildTimeout = this.kubernetes.maxBuildTimeout || MAX_BUILD_TIMEOUT;
         this.serviceAccount = this.kubernetes.serviceAccount || 'default';
+        this.automountServiceAccountToken =
+            this.kubernetes.automountServiceAccountToken === 'true' || false;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
         this.retryDelay = this.requestretryOptions.retryDelay || DEFAULT_RETRYDELAY;
@@ -398,6 +401,7 @@ class K8sExecutor extends Executor {
                 volumeReadOnly
             },
             service_account: this.serviceAccount,
+            automount_service_account_token: this.automountServiceAccountToken,
             docker: {
                 enabled: DOCKER_ENABLED,
                 cpu: DOCKER_CPU,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -163,6 +163,7 @@ describe('index', function () {
                 token: 'api_key2',
                 host: 'kubernetes2',
                 serviceAccount: 'foobar',
+                automountServiceAccountToken: 'true',
                 jobsNamespace: 'baz',
                 resources: {
                     cpu: {
@@ -189,6 +190,7 @@ describe('index', function () {
         assert.equal(executor.host, 'kubernetes2');
         assert.equal(executor.launchVersion, 'v1.2.3');
         assert.equal(executor.serviceAccount, 'foobar');
+        assert.equal(executor.automountServiceAccountToken, true);
         assert.equal(executor.jobsNamespace, 'baz');
         assert.equal(executor.turboCpu, 10);
         assert.equal(executor.highCpu, 8);
@@ -207,6 +209,7 @@ describe('index', function () {
         assert.equal(executor.maxBuildTimeout, MAX_BUILD_TIMEOUT);
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
+        assert.equal(executor.automountServiceAccountToken, false);
         assert.equal(executor.token, '');
         assert.equal(executor.host, 'kubernetes.default');
         assert.equal(executor.launchVersion, 'stable');


### PR DESCRIPTION
## Context

* deprecate the use of "serviceAccount" for "serviceAccountName"
* make option for turning on automount of sa token

## Objective

add config for serviceAccountName and automountServiceAccountToken

## References

https://github.com/screwdriver-cd/screwdriver/issues/1955

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
