### PR TITLE
feat(818): push image name metrics to prometheus

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -20,8 +20,14 @@ spec:
       limits:
         cpu: {{cpu}}m
         memory: {{memory}}Gi
-    {{#if docker.enabled}}
     env:
+      - name: PUSHGATEWAY_URL
+        value: {{pushgateway_url}}
+      - name: CONTAINER_IMAGE
+        value: {{container}}
+      - name: SD_PIPELINE_ID
+        value: {{pipeline_id}}
+    {{#if docker.enabled}}
       - name: DOCKER_HOST
         value: tcp://localhost:2375
     {{/if}}


### PR DESCRIPTION
## Context

Top images to be cached in the node are not available as part of the node warm-up.

## Objective

Send image metrics to Prometheus via pushgateway configuration. These metrics will be used to query top n images and cached in node as part of the node warm-up. 

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)
[Launcher PR-335](https://github.com/screwdriver-cd/launcher/pull/335)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
