### PR TITLE
feat(818): remove disk label config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ const DEFAULT_MAXATTEMPTS = 5;
 const DEFAULT_RETRYDELAY = 3000;
 const CPU_RESOURCE = 'cpu';
 const RAM_RESOURCE = 'ram';
-const DISK_RESOURCE = 'disk';
 const DISK_SPEED_RESOURCE = 'diskSpeed';
 const ANNOTATE_BUILD_TIMEOUT = 'timeout';
 const TOLERATIONS_PATH = 'spec.tolerations';
@@ -206,7 +205,6 @@ class K8sExecutor extends Executor {
         this.highMemory = hoek.reach(options, 'kubernetes.resources.memory.high', { default: 12 });
         this.lowMemory = hoek.reach(options, 'kubernetes.resources.memory.low', { default: 2 });
         this.microMemory = hoek.reach(options, 'kubernetes.resources.memory.micro', { default: 1 });
-        this.diskLabel = hoek.reach(options, 'kubernetes.resources.disk.space', { default: '' });
         this.diskSpeedLabel = hoek.reach(options,
             'kubernetes.resources.disk.speed', { default: '' });
         this.nodeSelectors = hoek.reach(options, 'kubernetes.nodeSelectors');
@@ -410,13 +408,6 @@ class K8sExecutor extends Executor {
         });
         const podConfig = yaml.safeLoad(podTemplate);
         const nodeSelectors = {};
-
-        if (this.diskLabel) {
-            const diskConfig = (annotations[DISK_RESOURCE] || '').toLowerCase();
-            const diskSelectors = diskConfig ? { [this.diskLabel]: diskConfig } : {};
-
-            hoek.merge(nodeSelectors, diskSelectors);
-        }
 
         if (this.diskSpeedLabel) {
             const diskSpeedConfig = (annotations[DISK_SPEED_RESOURCE] || '').toLowerCase();


### PR DESCRIPTION
## Context

Disk size customization not needed in contained + kata setup. By default, the container gets the max disk size based on the container storage setup. For docker runtime, it's possible via [docker-set-storage-options-per-container](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container)

## Objective

This PR removes disk label config.

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
