### PR TITLE
feat(818): optimize initcontainer setup time, add runtimeclass for kata

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -7,8 +7,8 @@ metadata:
     app: screwdriver
     tier: builds
 spec:
-  {{#if runtimeClassName}}
-  runtimeClassName: {{runtimeClassName}}
+  {{#if runtimeClass}}
+  runtimeClassName: {{runtimeClass}}
   {{/if}}
   serviceAccountName: {{service_account}}
   automountServiceAccountToken: {{automount_service_account_token}}

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -7,6 +7,9 @@ metadata:
     app: screwdriver
     tier: builds
 spec:
+  {{#if runtimeClassName}}
+  runtimeClassName: {{runtimeClassName}}
+  {{/if}}
   serviceAccountName: {{service_account}}
   automountServiceAccountToken: {{automount_service_account_token}}
   restartPolicy: Never
@@ -31,6 +34,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: spec.nodeName
+      - name: SD_BASE_COMMAND_PATH
+        value: "/sd/commands/"
+      - name: SD_TEMP
+        value: "/opt/sd_tmp"
     {{#if docker.enabled}}
       - name: DOCKER_HOST
         value: tcp://localhost:2375
@@ -48,10 +55,11 @@ spec:
     volumeMounts:
     - mountPath: /opt/sd
       name: screwdriver
-    - mountPath: /sd
+      readOnly: true
+    - mountPath: /opt/sd_tmp
+      name: sdtemp
+    - mountPath: /workspace
       name: workspace
-    - mountPath: /hab
-      name: habitat
     {{#if cache.diskEnabled}}
     - mountPath: /sdpipelinecache
       name: sd-pipeline-cache
@@ -79,15 +87,13 @@ spec:
   - name: launcher
     image: {{launcher_image}}
     {{#if cache.diskEnabled}}
-    command: ['/bin/sh', '-c', 'chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && cp -a /opt/sd/* /opt/launcher && cp -a /hab/* /opt/hab']
+    command: ['/bin/sh', '-c', 'chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
     {{else}}
-    command: ['/bin/sh', '-c', 'cp -a /opt/sd/* /opt/launcher && cp -a /hab/* /opt/hab']
+    command: ['/bin/sh', '-c', 'if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
     {{/if}}
     volumeMounts:
     - mountPath: /opt/launcher
       name: screwdriver
-    - mountPath: /opt/hab
-      name: habitat
     {{#if cache.diskEnabled}}
     - mountPath: /opt/sdpipelinecache
       name: sd-pipeline-cache
@@ -98,9 +104,13 @@ spec:
     {{/if}}
   volumes:
     - name: screwdriver
-      emptyDir: {}
-    - name: habitat
-      emptyDir: {}
+      type: DirectoryOrCreate
+      hostPath:
+        path: /opt/screwdriver/sdlauncher/{{launcher_version}}
+    - name: sdtemp
+      type: DirectoryOrCreate
+      hostPath:
+        path: /opt/screwdriver/tmp_{{build_id}}
     - name: workspace
       emptyDir: {}
     {{#if docker.enabled}}
@@ -121,3 +131,4 @@ spec:
       hostPath:
         path: {{cache.path}}/events/{{pipeline_id}}/{{event_id}}
     {{/if}}
+

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ class K8sExecutor extends Executor {
             this.token = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath).toString() : '';
         }
         this.host = this.kubernetes.host || 'kubernetes.default';
-        this.runtimeClassName = this.kubernetes.runtimeClassName || '';
+        this.runtimeClass = this.kubernetes.runtimeClass || '';
         this.launchImage = options.launchImage || 'screwdrivercd/launcher';
         this.launchVersion = options.launchVersion || 'stable';
         this.prefix = options.prefix || '';
@@ -371,7 +371,7 @@ class K8sExecutor extends Executor {
             }
         }
         const podTemplate = template({
-            runtimeClassName: this.runtimeClassName,
+            runtimeClass: this.runtimeClass,
             cpu,
             memory,
             pod_name: `${this.prefix}${buildId}-${random}`,

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ class K8sExecutor extends Executor {
             this.token = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath).toString() : '';
         }
         this.host = this.kubernetes.host || 'kubernetes.default';
+        this.runtimeClassName = this.kubernetes.runtimeClassName || '';
         this.launchImage = options.launchImage || 'screwdrivercd/launcher';
         this.launchVersion = options.launchVersion || 'stable';
         this.prefix = options.prefix || '';
@@ -370,6 +371,7 @@ class K8sExecutor extends Executor {
             }
         }
         const podTemplate = template({
+            runtimeClassName: this.runtimeClassName,
             cpu,
             memory,
             pod_name: `${this.prefix}${buildId}-${random}`,


### PR DESCRIPTION
## Context

Launcher container takes approx ~12secs due to hab install n copy. Support kata for Kubernetes version v1.12.0 or above.

## Objective

Speed up launcher container setup time using symlink for hab. This is already available in executor-k8s-vm -> hyper route, porting it to executor-k8s. Add runtime class option to support kata for kubernetes higher version v1.12.0 or above [kata-containers-as-a-runtimeclass](https://github.com/kata-containers/documentation/blob/master/how-to/containerd-kata.md#kata-containers-as-a-runtimeclass).

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
