### PR TITLE
feat(818): add metrics file to support missing metrics push to prometheus

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -14,7 +14,7 @@ spec:
   automountServiceAccountToken: {{automount_service_account_token}}
   restartPolicy: Never
   containers:
-  - name: build
+  - name: "{{build_id_with_prefix}}"
     image: {{container}}
     imagePullPolicy: Always
     securityContext:
@@ -87,13 +87,15 @@ spec:
   - name: launcher
     image: {{launcher_image}}
     {{#if cache.diskEnabled}}
-    command: ['/bin/sh', '-c', 'chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; && echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
     {{else}}
-    command: ['/bin/sh', '-c', 'if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi;']
+    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; && echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
     {{/if}}
     volumeMounts:
     - mountPath: /opt/launcher
       name: screwdriver
+    - mountPath: /workspace
+      name: workspace
     {{#if cache.diskEnabled}}
     - mountPath: /opt/sdpipelinecache
       name: sd-pipeline-cache

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -87,9 +87,9 @@ spec:
   - name: launcher
     image: {{launcher_image}}
     {{#if cache.diskEnabled}}
-    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; && echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
+    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
     {{else}}
-    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; && echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
+    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
     {{/if}}
     volumeMounts:
     - mountPath: /opt/launcher


### PR DESCRIPTION
## Context

add metrics file in workspace dir to support missing metrics push to Prometheus

## Objective

Add metrics file in workspace dir and update launcher start and end timestamp

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)
[Launcher PR#342](https://github.com/screwdriver-cd/launcher/pull/342)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.