### PR TITLE
fix(818): add suffix build id to launcher container

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -84,7 +84,7 @@ spec:
         mountPath: /var/lib/docker
   {{/if}}
   initContainers:
-  - name: launcher
+  - name: "launcher-{{build_id_with_prefix}}"
     image: {{launcher_image}}
     {{#if cache.diskEnabled}}
     command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/* $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']


### PR DESCRIPTION
## Objective

Suffix buildid-with-prefix to the launcher container name, similar to build container name.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
