### PR TITLE
fix(818): add sd environment to env var

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -30,7 +30,7 @@ spec:
         value: {{container}}
       - name: SD_PIPELINE_ID
         value: "{{pipeline_id}}"
-      - name: SD_ENVIRONMENT
+      - name: SD_BUILD_PREFIX
         value: "{{prefix}}"
       - name: NODE_ID
         valueFrom:

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -30,6 +30,8 @@ spec:
         value: {{container}}
       - name: SD_PIPELINE_ID
         value: "{{pipeline_id}}"
+      - name: SD_ENVIRONMENT
+        value: "{{prefix}}"
       - name: NODE_ID
         valueFrom:
           fieldRef:

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ class K8sExecutor extends Executor {
      * @param  {Object}  [options.kubernetes.nodeSelectors]                      Object representing node label-value pairs
      * @param  {Object}  [options.kubernetes.lifecycleHooks]                     Object representing pod lifecycle hooks
      * @param  {String}  [options.launchVersion=stable]                          Launcher container version to use
-     * @param  {String}  [options.prefix='']                                     Prefix for job name
+     * @param  {String}  [options.prefix='']                                      Prefix for job name
      * @param  {String}  [options.fusebox]                                       Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
      * @param  {Object}  [options.requestretry]                                  Options for the requestretry (https://github.com/FGRibreau/node-request-retry)
      * @param  {Number}  [options.requestretry.retryDelay]                       Value for retryDelay option of the requestretry

--- a/index.js
+++ b/index.js
@@ -406,6 +406,7 @@ class K8sExecutor extends Executor {
             pod_name: `${buildContainerName}-${random}`,
             privileged: this.privileged,
             build_id_with_prefix: buildContainerName,
+            prefix: this.prefix,
             build_id: buildId,
             job_id: jobId,
             pipeline_id: pipelineId,


### PR DESCRIPTION
## Context

pipeline-id/job-id/build-id is available in both beta and prod environments, which results in incorrect metrics.

## Objective

Add sd environment to metrics data.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)
[Launcher PR-352](https://github.com/screwdriver-cd/launcher/pull/352)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
