### PR TITLE
fix: revert cpu config to support 0.5 values

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -21,7 +21,7 @@ spec:
       privileged: {{privileged}}
     resources:
       limits:
-        cpu: {{cpu}}
+        cpu: {{cpu}}m
         memory: {{memory}}Gi
     env:
       - name: SD_RUNTIME_CLASS


### PR DESCRIPTION
## Objective

Revert CPU config to support 0.5

## References

https://github.com/screwdriver-cd/executor-k8s/pull/127

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
