### PR TITLE
fix: custom memory value errors with invalid pod spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,6 +226,7 @@ class K8sExecutor extends Executor {
         this.highCpu = hoek.reach(options, 'kubernetes.resources.cpu.high', { default: 6 });
         this.lowCpu = hoek.reach(options, 'kubernetes.resources.cpu.low', { default: 2 });
         this.microCpu = hoek.reach(options, 'kubernetes.resources.cpu.micro', { default: 0.5 });
+        this.maxMemory = hoek.reach(options, 'kubernetes.resources.memory.max', { default: 16 });
         this.turboMemory = hoek.reach(options,
             'kubernetes.resources.memory.turbo', { default: 16 });
         this.highMemory = hoek.reach(options, 'kubernetes.resources.memory.high', { default: 12 });

--- a/index.js
+++ b/index.js
@@ -169,6 +169,7 @@ class K8sExecutor extends Executor {
      * @param  {String}  [options.kubernetes.resources.cpu.high=6]               Value for HIGH CPU (in cores)
      * @param  {Number}  [options.kubernetes.resources.cpu.low=2]                Value for LOW CPU (in cores)
      * @param  {Number}  [options.kubernetes.resources.cpu.micro=0.5]            Value for MICRO CPU (in cores)
+     * @param  {Number}  [options.kubernetes.resources.memory.max=16]            Value for MAX memory, upper bound for custom memory value (in GB)
      * @param  {Number}  [options.kubernetes.resources.memory.turbo=16]          Value for TURBO memory (in GB)
      * @param  {Number}  [options.kubernetes.resources.memory.high=12]           Value for HIGH memory (in GB)
      * @param  {Number}  [options.kubernetes.resources.memory.low=2]             Value for LOW memory (in GB)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -486,6 +486,17 @@ describe('index', function () {
             });
         });
 
+        it('sets the memory appropriately when ram is set to Integer', () => {
+            postConfig.json.metadata.cpu = 2000;
+            postConfig.json.metadata.memory = 16;
+            fakeStartConfig.annotations['beta.screwdriver.cd/ram'] = 64;
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
+
         it('sets the cpu appropriately when cpu is set to HIGH', () => {
             postConfig.json.metadata.cpu = 6000;
             postConfig.json.metadata.memory = 2;


### PR DESCRIPTION
## Context

Custom memory value in annotation `screwdriver.cd/ram: 64` errors with invalid pod specification - ` Error: Failed to create pod: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod in version \"v1\" cannot be handled as a Pod: v1.Pod.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: Resources: v1.ResourceRequirements.Limits: unmarshalerDecoder: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$', error found in #10 byte of ...|y\":\"NaNGi\"}},\"env\":[|..., bigger context ...|ources\":{\"limits\":{\"cpu\":\"16000m\",\"memory\":\"NaNGi\"}},"reason":"BadRequest","code":400} `

## Objective

this.maxMemory is not configured and returning NaN for line# https://github.com/screwdriver-cd/executor-k8s/blob/master/index.js#L364, add this.maxMemory config.

## References

[this.maxMemory config in executor-k8s-vm](https://github.com/screwdriver-cd/executor-k8s-vm/blob/master/index.js#L176)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
