### PR TITLE
fix: init step errors not propagated back to API

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const DOCKER_CPU_RESOURCE = 'dockerCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
 const PR_JOBNAME_REGEX_PATTERN = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
-const STATUS_FAILED = 'FAILED';
+const STATUS_FAILED = 'FAILURE';
 
 /**
  * Parses annotations config and update intended annotations

--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class K8sExecutor extends Executor {
     /**
      * Update build
      * @method updateBuild
-     * @param  {{apiUri: string, buildId: Integer, token: String}}          config                 build config of the job
+     * @param  {Object}          config                 build config of the job
      * @param  {String}          config.apiUri          screwdriver base api uri
      * @param  {Number}          config.buildId         build id
      * @param  {Object}          [config.stats]         build stats

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const DOCKER_CPU_RESOURCE = 'dockerCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
 const PR_JOBNAME_REGEX_PATTERN = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
-const STATUS_FAILED = 'FAILURE';
+const BUILD_STATUS_FAILURE = 'FAILURE';
 
 /**
  * Parses annotations config and update intended annotations
@@ -504,14 +504,14 @@ class K8sExecutor extends Executor {
 
                 if (resp.statusCode !== 200) {
                     error = `Failed to get pod status:${JSON.stringify(resp.body, null, 2)}`;
-                    updateConfig.status = STATUS_FAILED;
+                    updateConfig.status = BUILD_STATUS_FAILURE;
                     updateConfig.statusMessage = error;
                 } else {
                     const status = resp.body.status.phase.toLowerCase();
 
                     if (status === 'failed' || status === 'unknown') {
                         error = `Failed to create pod. Pod status is:${JSON.stringify(resp.body.status, null, 2)}`;
-                        updateConfig.status = STATUS_FAILED;
+                        updateConfig.status = BUILD_STATUS_FAILURE;
                         updateConfig.statusMessage = error;
                     } else if (resp.body.spec && resp.body.spec.nodeName) {
                         updateConfig.stats = {
@@ -550,7 +550,7 @@ class K8sExecutor extends Executor {
                         apiUri: this.ecosystem.api,
                         buildId,
                         token,
-                        status: STATUS_FAILED,
+                        status: BUILD_STATUS_FAILURE,
                         statusMessage: error
                     };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,7 @@ const _ = require('lodash');
 
 sinon.assert.expose(assert, { prefix: '' });
 
+const STATUS_FAILED = 'FAILURE';
 const DEFAULT_BUILD_TIMEOUT = 90;
 const MAX_BUILD_TIMEOUT = 120;
 const TEST_TIM_YAML = `
@@ -725,7 +726,7 @@ describe('index', function() {
             };
             const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
-            putConfig.body.status = 'FAILED';
+            putConfig.body.status = STATUS_FAILED;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -757,7 +758,7 @@ describe('index', function() {
                 2
             )}`;
 
-            putConfig.body.status = 'FAILED';
+            putConfig.body.status = STATUS_FAILED;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -795,7 +796,7 @@ describe('index', function() {
             };
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
-            putConfig.body.status = 'FAILED';
+            putConfig.body.status = STATUS_FAILED;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -834,7 +835,7 @@ describe('index', function() {
 
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
-            putConfig.body.status = 'FAILED';
+            putConfig.body.status = STATUS_FAILED;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -867,7 +868,7 @@ describe('index', function() {
                 2
             )}`;
 
-            putConfig.body.status = 'FAILED';
+            putConfig.body.status = STATUS_FAILED;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -894,7 +895,7 @@ describe('index', function() {
             };
             const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
-            putConfig.body.status = 'FAILED';
+            putConfig.body.status = STATUS_FAILED;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,7 @@ const _ = require('lodash');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-const STATUS_FAILED = 'FAILURE';
+const BUILD_STATUS_FAILURE = 'FAILURE';
 const DEFAULT_BUILD_TIMEOUT = 90;
 const MAX_BUILD_TIMEOUT = 120;
 const TEST_TIM_YAML = `
@@ -726,7 +726,7 @@ describe('index', function() {
             };
             const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
-            putConfig.body.status = STATUS_FAILED;
+            putConfig.body.status = BUILD_STATUS_FAILURE;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -758,7 +758,7 @@ describe('index', function() {
                 2
             )}`;
 
-            putConfig.body.status = STATUS_FAILED;
+            putConfig.body.status = BUILD_STATUS_FAILURE;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -796,7 +796,7 @@ describe('index', function() {
             };
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
-            putConfig.body.status = STATUS_FAILED;
+            putConfig.body.status = BUILD_STATUS_FAILURE;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -835,7 +835,7 @@ describe('index', function() {
 
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
-            putConfig.body.status = STATUS_FAILED;
+            putConfig.body.status = BUILD_STATUS_FAILURE;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -868,7 +868,7 @@ describe('index', function() {
                 2
             )}`;
 
-            putConfig.body.status = STATUS_FAILED;
+            putConfig.body.status = BUILD_STATUS_FAILURE;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -895,7 +895,7 @@ describe('index', function() {
             };
             const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
-            putConfig.body.status = STATUS_FAILED;
+            putConfig.body.status = BUILD_STATUS_FAILURE;
             putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('chai').assert;
+const { assert } = require('chai');
 const sinon = require('sinon');
 const mockery = require('mockery');
 const yaml = require('js-yaml');
@@ -725,6 +725,8 @@ describe('index', function() {
             };
             const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
+            putConfig.body.status = 'FAILED';
+            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -732,6 +734,9 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -752,6 +757,8 @@ describe('index', function() {
                 2
             )}`;
 
+            putConfig.body.status = 'FAILED';
+            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -759,6 +766,9 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -783,9 +793,10 @@ describe('index', function() {
                     }
                 }
             };
-
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
+            putConfig.body.status = 'FAILED';
+            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -793,6 +804,9 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledTwice);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -820,6 +834,8 @@ describe('index', function() {
 
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
+            putConfig.body.status = 'FAILED';
+            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -827,6 +843,9 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledTwice);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -841,12 +860,15 @@ describe('index', function() {
                     }
                 }
             };
+
             const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2
             )}`;
 
+            putConfig.body.status = 'FAILED';
+            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -854,6 +876,9 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -867,15 +892,20 @@ describe('index', function() {
                     message: 'lol'
                 }
             };
-            const returnMessage = `Failed to create pod:${JSON.stringify(returnResponse.body)}`;
+            const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
-            requestRetryMock.withArgs(postConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+            putConfig.body.status = 'FAILED';
+            putConfig.body.statusMessage = returnMessage;
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
                 () => {
                     throw new Error('did not fail');
                 },
                 err => {
+                    assert.calledWith(requestRetryMock.firstCall, postConfig);
+                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assert } = require('chai');
+const assert = require('chai').assert;
 const sinon = require('sinon');
 const mockery = require('mockery');
 const yaml = require('js-yaml');


### PR DESCRIPTION
## Context

In Kata setup, build hangs indefinitely for any errors in build init step.

## Objective

Update build status and status message for any errors in build init step.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
