### PR TITLE
Revert "fix: init step errors not propagated back to API"

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,6 @@ const _ = require('lodash');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-const BUILD_STATUS_FAILURE = 'FAILURE';
 const DEFAULT_BUILD_TIMEOUT = 90;
 const MAX_BUILD_TIMEOUT = 120;
 const TEST_TIM_YAML = `
@@ -726,8 +725,6 @@ describe('index', function() {
             };
             const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
-            putConfig.body.status = BUILD_STATUS_FAILURE;
-            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -735,9 +732,6 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
-                    assert.calledWith(requestRetryMock.firstCall, postConfig);
-                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -758,8 +752,6 @@ describe('index', function() {
                 2
             )}`;
 
-            putConfig.body.status = BUILD_STATUS_FAILURE;
-            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -767,9 +759,6 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
-                    assert.calledWith(requestRetryMock.firstCall, postConfig);
-                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -794,10 +783,9 @@ describe('index', function() {
                     }
                 }
             };
+
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
-            putConfig.body.status = BUILD_STATUS_FAILURE;
-            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -805,9 +793,6 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
-                    assert.calledWith(requestRetryMock.firstCall, postConfig);
-                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledTwice);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -835,8 +820,6 @@ describe('index', function() {
 
             const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
-            putConfig.body.status = BUILD_STATUS_FAILURE;
-            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -844,9 +827,6 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
-                    assert.calledWith(requestRetryMock.firstCall, postConfig);
-                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledTwice);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -861,15 +841,12 @@ describe('index', function() {
                     }
                 }
             };
-
             const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2
             )}`;
 
-            putConfig.body.status = BUILD_STATUS_FAILURE;
-            putConfig.body.statusMessage = returnMessage;
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
@@ -877,9 +854,6 @@ describe('index', function() {
                     throw new Error('did not fail');
                 },
                 err => {
-                    assert.calledWith(requestRetryMock.firstCall, postConfig);
-                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );
@@ -893,20 +867,15 @@ describe('index', function() {
                     message: 'lol'
                 }
             };
-            const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
+            const returnMessage = `Failed to create pod:${JSON.stringify(returnResponse.body)}`;
 
-            putConfig.body.status = BUILD_STATUS_FAILURE;
-            putConfig.body.statusMessage = returnMessage;
-            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+            requestRetryMock.withArgs(postConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
             return executor.start(fakeStartConfig).then(
                 () => {
                     throw new Error('did not fail');
                 },
                 err => {
-                    assert.calledWith(requestRetryMock.firstCall, postConfig);
-                    assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-                    assert.equal(true, requestRetryMock.withArgs(putConfig).calledOnce);
                     assert.equal(err.message, returnMessage);
                 }
             );


### PR DESCRIPTION
Reverts screwdriver-cd/executor-k8s#136

this works in opensource without any changes; will do some more checks why its not working internally and re-raise this PR if needed.