### PR TITLE
fix: init container stuck doesnt propagate error

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,11 +262,11 @@ class K8sExecutor extends Executor {
                 !status ||
                 (status.toLowerCase() === 'pending' &&
                     waitingReason !== 'CrashLoopBackOff' &&
+                    waitingReason !== 'CreateContainerConfigError' &&
+                    waitingReason !== 'CreateContainerError' &&
                     waitingReason !== 'ErrImagePull' &&
                     waitingReason !== 'ImagePullBackOff' &&
-                    waitingReason !== 'CreateContainerConfigError' &&
-                    waitingReason !== 'InvalidImageName' &&
-                    waitingReason !== 'CreateContainerError')
+                    waitingReason !== 'InvalidImageName')
             );
         };
     }
@@ -539,11 +539,11 @@ class K8sExecutor extends Executor {
 
                 if (
                     waitingReason === 'CrashLoopBackOff' ||
+                    waitingReason === 'CreateContainerConfigError' ||
+                    waitingReason === 'CreateContainerError' ||
                     waitingReason === 'ErrImagePull' ||
                     waitingReason === 'ImagePullBackOff' ||
-                    waitingReason === 'CreateContainerConfigError' ||
-                    waitingReason === 'InvalidImageName' ||
-                    waitingReason === 'CreateContainerError'
+                    waitingReason === 'InvalidImageName'
                 ) {
                     throw new Error('Build failed to start. Please check if your image is valid.');
                 }

--- a/index.js
+++ b/index.js
@@ -261,8 +261,12 @@ class K8sExecutor extends Executor {
                 err ||
                 !status ||
                 (status.toLowerCase() === 'pending' &&
+                    waitingReason !== 'CrashLoopBackOff' &&
                     waitingReason !== 'ErrImagePull' &&
-                    waitingReason !== 'ImagePullBackOff')
+                    waitingReason !== 'ImagePullBackOff' &&
+                    waitingReason !== 'CreateContainerConfigError' &&
+                    waitingReason !== 'InvalidImageName' &&
+                    waitingReason !== 'CreateContainerError')
             );
         };
     }
@@ -533,7 +537,14 @@ class K8sExecutor extends Executor {
             .then(res => {
                 const waitingReason = hoek.reach(res.body, CONTAINER_WAITING_REASON_PATH);
 
-                if (waitingReason === 'ErrImagePull' || waitingReason === 'ImagePullBackOff') {
+                if (
+                    waitingReason === 'CrashLoopBackOff' ||
+                    waitingReason === 'ErrImagePull' ||
+                    waitingReason === 'ImagePullBackOff' ||
+                    waitingReason === 'CreateContainerConfigError' ||
+                    waitingReason === 'InvalidImageName' ||
+                    waitingReason === 'CreateContainerError'
+                ) {
                     throw new Error('Build failed to start. Please check if your image is valid.');
                 }
 

--- a/index.js
+++ b/index.js
@@ -540,7 +540,12 @@ class K8sExecutor extends Executor {
                 if (
                     waitingReason === 'CrashLoopBackOff' ||
                     waitingReason === 'CreateContainerConfigError' ||
-                    waitingReason === 'CreateContainerError' ||
+                    waitingReason === 'CreateContainerError'
+                ) {
+                    throw new Error('Build failed to start. Please reach out to your cluster admin for help.');
+                }
+
+                if (
                     waitingReason === 'ErrImagePull' ||
                     waitingReason === 'ImagePullBackOff' ||
                     waitingReason === 'InvalidImageName'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -764,6 +764,40 @@ describe('index', function() {
             );
         });
 
+        it('returns error when pod waiting reason is CrashLoopBackOff', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'CrashLoopBackOff',
+                                        message: 'crash loop backoff'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
         it('returns error when pod waiting reason is ErrImagePull', () => {
             const returnResponse = {
                 statusCode: 200,
@@ -810,6 +844,108 @@ describe('index', function() {
                                     waiting: {
                                         reason: 'ImagePullBackOff',
                                         message: 'can not pull image'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
+        it('returns error when pod waiting reason is CreateContainerConfigError', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'CreateContainerConfigError',
+                                        message: 'create container config error'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
+        it('returns error when pod waiting reason is InvalidImageName', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'InvalidImageName',
+                                        message: 'invalid reference format'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
+        it('returns error when pod waiting reason is CreateContainerError', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'CreateContainerError',
+                                        message: 'create container error'
                                     }
                                 }
                             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -784,7 +784,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -818,7 +818,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -852,7 +852,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -798,6 +798,74 @@ describe('index', function() {
             );
         });
 
+        it('returns error when pod waiting reason is CreateContainerConfigError', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'CreateContainerConfigError',
+                                        message: 'create container config error'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
+        it('returns error when pod waiting reason is CreateContainerError', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'CreateContainerError',
+                                        message: 'create container error'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
         it('returns error when pod waiting reason is ErrImagePull', () => {
             const returnResponse = {
                 statusCode: 200,
@@ -866,40 +934,6 @@ describe('index', function() {
             );
         });
 
-        it('returns error when pod waiting reason is CreateContainerConfigError', () => {
-            const returnResponse = {
-                statusCode: 200,
-                body: {
-                    status: {
-                        phase: 'pending',
-                        containerStatuses: [
-                            {
-                                state: {
-                                    waiting: {
-                                        reason: 'CreateContainerConfigError',
-                                        message: 'create container config error'
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            };
-
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
-
-            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
-
-            return executor.start(fakeStartConfig).then(
-                () => {
-                    throw new Error('did not fail');
-                },
-                err => {
-                    assert.equal(err.message, returnMessage);
-                }
-            );
-        });
-
         it('returns error when pod waiting reason is InvalidImageName', () => {
             const returnResponse = {
                 statusCode: 200,
@@ -912,40 +946,6 @@ describe('index', function() {
                                     waiting: {
                                         reason: 'InvalidImageName',
                                         message: 'invalid reference format'
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            };
-
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
-
-            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
-
-            return executor.start(fakeStartConfig).then(
-                () => {
-                    throw new Error('did not fail');
-                },
-                err => {
-                    assert.equal(err.message, returnMessage);
-                }
-            );
-        });
-
-        it('returns error when pod waiting reason is CreateContainerError', () => {
-            const returnResponse = {
-                statusCode: 200,
-                body: {
-                    status: {
-                        phase: 'pending',
-                        containerStatuses: [
-                            {
-                                state: {
-                                    waiting: {
-                                        reason: 'CreateContainerError',
-                                        message: 'create container error'
                                     }
                                 }
                             }


### PR DESCRIPTION
## Context

In Kata setup, build hangs indefinitely in init step for listed container waiting reasons 1. CrashLoopBackOff, 2. CreateContainerConfigError, 3. InvalidImageName, 4. CreateContainerError

## Objective

Include additional container waiting reasons check 1. CrashLoopBackOff, 2. CreateContainerConfigError, 3. InvalidImageName, 4. CreateContainerError as part of pending retry strategy evaluation.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
