### PR TITLE
fix: add container waiting reason - StartError

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,8 @@ class K8sExecutor extends Executor {
                     waitingReason !== 'CreateContainerError' &&
                     waitingReason !== 'ErrImagePull' &&
                     waitingReason !== 'ImagePullBackOff' &&
-                    waitingReason !== 'InvalidImageName')
+                    waitingReason !== 'InvalidImageName' &&
+                    waitingReason !== 'StartError')
             );
         };
     }
@@ -540,7 +541,8 @@ class K8sExecutor extends Executor {
                 if (
                     waitingReason === 'CrashLoopBackOff' ||
                     waitingReason === 'CreateContainerConfigError' ||
-                    waitingReason === 'CreateContainerError'
+                    waitingReason === 'CreateContainerError' ||
+                    waitingReason === 'StartError'
                 ) {
                     throw new Error('Build failed to start. Please reach out to your cluster admin for help.');
                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -968,6 +968,40 @@ describe('index', function() {
             );
         });
 
+        it('returns error when pod waiting reason is StartError', () => {
+            const returnResponse = {
+                statusCode: 200,
+                body: {
+                    status: {
+                        phase: 'pending',
+                        containerStatuses: [
+                            {
+                                state: {
+                                    waiting: {
+                                        reason: 'StartError',
+                                        message: 'mount path errors'
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            };
+
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
+
+            requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
+
+            return executor.start(fakeStartConfig).then(
+                () => {
+                    throw new Error('did not fail');
+                },
+                err => {
+                    assert.equal(err.message, returnMessage);
+                }
+            );
+        });
+
         it('sets error when pod status is failed', () => {
             const returnResponse = {
                 statusCode: 200,


### PR DESCRIPTION
## Context

In Kata setup, build hangs indefinitely in init step for "StartError" container waiting reason

## Objective

Include "StartError" container waiting reasons as part of pending retry strategy evaluation.

## References

PR https://github.com/screwdriver-cd/executor-k8s/pull/138

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
