### PR TITLE
fix: capture error when scheduling k8s pod

### DIFF
--- a/index.js
+++ b/index.js
@@ -537,6 +537,11 @@ class K8sExecutor extends Executor {
             })
             .then(res => {
                 const waitingReason = hoek.reach(res.body, CONTAINER_WAITING_REASON_PATH);
+                const status = res.body.status.phase.toLowerCase();
+
+                if (status === 'failed' || status === 'unknown') {
+                    throw new Error(`Failed to create pod. Pod status is:${JSON.stringify(res.body.status, null, 2)}`);
+                }
 
                 if (
                     waitingReason === 'CrashLoopBackOff' ||


### PR DESCRIPTION
## Context

When pod is scheduled with invalid image or container without sudo permission it should fail consistently and update build status and message appropriately, but it works intermittently. 

## Objective

This could be due to delay in k8s updating pod status to failed. Add pod failed status check along-with container state waiting reason check.

## References

https://github.com/screwdriver-cd/executor-k8s/pull/138
https://github.com/screwdriver-cd/executor-k8s/pull/139

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
