### PR TITLE
fix: capture error when scheduling k8s pod

### DIFF
--- a/index.js
+++ b/index.js
@@ -553,7 +553,9 @@ class K8sExecutor extends Executor {
                     updateConfig.statusMessage = 'Waiting for resources to be available.';
                 }
 
-                this.updateBuild(updateConfig).then(() => new Promise(r => setTimeout(r, this.podStatusQueryDelay)));
+                return this.updateBuild(updateConfig).then(
+                    () => new Promise(r => setTimeout(r, this.podStatusQueryDelay))
+                );
             })
             .then(() => {
                 const statusOptions = {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const DOCKER_CPU_RESOURCE = 'dockerCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
 const PR_JOBNAME_REGEX_PATTERN = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
-const POD_STATUS_QUERY_RETRYDELAY_MS = 500;
+const POD_STATUSQUERY_RETRYDELAY_MS = 500;
 
 /**
  * Parses annotations config and update intended annotations
@@ -236,7 +236,7 @@ class K8sExecutor extends Executor {
         this.preferredNodeSelectors = hoek.reach(options, 'kubernetes.preferredNodeSelectors');
         this.lifecycleHooks = hoek.reach(options, 'kubernetes.lifecycleHooks');
         this.volumeMounts = hoek.reach(options, 'kubernetes.volumeMounts', { default: {} });
-        this.podStatusQueryDelay = this.kubernetes.podStatusQueryDelay || POD_STATUS_QUERY_RETRYDELAY_MS;
+        this.podStatusQueryDelay = this.kubernetes.podStatusQueryDelay || POD_STATUSQUERY_RETRYDELAY_MS;
         this.cacheStrategy = hoek.reach(options, 'ecosystem.cache.strategy', { default: 's3' });
         this.cachePath = hoek.reach(options, 'ecosystem.cache.path', { default: '/' });
         this.cacheCompress = hoek.reach(options, 'ecosystem.cache.compress', { default: 'false' });

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const yaml = require('js-yaml');
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 const logger = require('screwdriver-logger');
+const sleep = require('sleep');
 
 const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
 const MAX_BUILD_TIMEOUT = 120; // 120 minutes
@@ -34,6 +35,7 @@ const DOCKER_CPU_RESOURCE = 'dockerCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
 const PR_JOBNAME_REGEX_PATTERN = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
+const POD_STATUS_QUERY_RETRYDELAY_MS = 2000;
 
 /**
  * Parses annotations config and update intended annotations
@@ -559,6 +561,7 @@ class K8sExecutor extends Executor {
                 }
             })
             .then(() => {
+                sleep.msleep(POD_STATUS_QUERY_RETRYDELAY_MS);
                 const statusOptions = {
                     uri: `${this.podsUrl}/${podname}/status`,
                     method: 'GET',

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const DOCKER_CPU_RESOURCE = 'dockerCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
 const PR_JOBNAME_REGEX_PATTERN = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
-const POD_STATUS_QUERY_RETRYDELAY_MS = 2000;
+const POD_STATUS_QUERY_RETRYDELAY_MS = 500;
 
 /**
  * Parses annotations config and update intended annotations
@@ -178,6 +178,7 @@ class K8sExecutor extends Executor {
      * @param  {Object}  [options.kubernetes.nodeSelectors]                      Object representing node label-value pairs
      * @param  {Object}  [options.kubernetes.lifecycleHooks]                     Object representing pod lifecycle hooks
      * @param  {Object}  [options.kubernetes.volumeMounts]                       Object representing pod volume mounts (e.g.: [ { "name": "kvm", "mountPath": "/dev/kvm", "path": "/dev/kvm/", "type": "File", "readOnly": true } ] )
+     * @param  {Number}  [options.kubernetes.podStatusQueryDelay]                Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
      * @param  {String}  [options.launchVersion=stable]                          Launcher container version to use
      * @param  {String}  [options.prefix='']                                     Prefix for job name
      * @param  {String}  [options.fusebox]                                       Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
@@ -235,6 +236,7 @@ class K8sExecutor extends Executor {
         this.preferredNodeSelectors = hoek.reach(options, 'kubernetes.preferredNodeSelectors');
         this.lifecycleHooks = hoek.reach(options, 'kubernetes.lifecycleHooks');
         this.volumeMounts = hoek.reach(options, 'kubernetes.volumeMounts', { default: {} });
+        this.podStatusQueryDelay = this.kubernetes.podStatusQueryDelay || POD_STATUS_QUERY_RETRYDELAY_MS;
         this.cacheStrategy = hoek.reach(options, 'ecosystem.cache.strategy', { default: 's3' });
         this.cachePath = hoek.reach(options, 'ecosystem.cache.path', { default: '/' });
         this.cacheCompress = hoek.reach(options, 'ecosystem.cache.compress', { default: 'false' });
@@ -561,7 +563,7 @@ class K8sExecutor extends Executor {
                 }
             })
             .then(() => {
-                sleep.msleep(POD_STATUS_QUERY_RETRYDELAY_MS);
+                sleep.msleep(this.podStatusQueryDelay);
                 const statusOptions = {
                     uri: `${this.podsUrl}/${podname}/status`,
                     method: 'GET',

--- a/index.js
+++ b/index.js
@@ -287,7 +287,6 @@ class K8sExecutor extends Executor {
         logger.info('k8s pod response ', JSON.stringify(resp));
 
         if (resp.statusCode !== 200) {
-            // return `Failed to get pod status:${JSON.stringify(resp.body, null, 2)}`;
             return Promise.reject(new Error(`Failed to get pod status:${JSON.stringify(resp.body, null, 2)}`));
         }
 
@@ -295,7 +294,6 @@ class K8sExecutor extends Executor {
         const waitingReason = hoek.reach(resp.body, CONTAINER_WAITING_REASON_PATH);
 
         if (status === 'failed' || status === 'unknown') {
-            // return `Failed to create pod. Pod status is:${JSON.stringify(resp.body.status, null, 2)}`;
             return Promise.reject(
                 new Error(`Failed to create pod. Pod status is:${JSON.stringify(resp.body.status, null, 2)}`)
             );
@@ -307,7 +305,6 @@ class K8sExecutor extends Executor {
             waitingReason === 'CreateContainerError' ||
             waitingReason === 'StartError'
         ) {
-            // return 'Build failed to start. Please reach out to your cluster admin for help.';
             return Promise.reject(new Error('Build failed to start. Please reach out to your cluster admin for help.'));
         }
 
@@ -316,7 +313,6 @@ class K8sExecutor extends Executor {
             waitingReason === 'ImagePullBackOff' ||
             waitingReason === 'InvalidImageName'
         ) {
-            // return 'Build failed to start. Please check if your image is valid.';
             return Promise.reject(new Error('Build failed to start. Please check if your image is valid.'));
         }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "requestretry": "^4.0.0",
     "screwdriver-executor-base": "^8.0.0",
     "screwdriver-logger": "^1.0.1",
-    "tinytim": "^0.1.1",
-    "sleep": "^6.3.0"
+    "tinytim": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "request": "^2.88.0",
     "requestretry": "^4.0.0",
     "screwdriver-executor-base": "^8.0.0",
-    "tinytim": "^0.1.1"
+    "tinytim": "^0.1.1",
+    "screwdriver-logger": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,13 @@
     "js-yaml": "^3.11.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.5",
+    "node-gyp": "^7.1.2",
     "randomstring": "^1.1.5",
     "request": "^2.88.0",
     "requestretry": "^4.0.0",
     "screwdriver-executor-base": "^8.0.0",
+    "screwdriver-logger": "^1.0.1",
     "tinytim": "^0.1.1",
-    "screwdriver-logger": "^1.0.1"
+    "sleep": "^6.3.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ describe('index', function() {
     let Executor;
     let requestRetryMock;
     let fsMock;
-    let fsSleep;
+    let sleepMock;
     let executor;
     const testBuildId = 15;
     const testToken = 'abcdefg';
@@ -160,18 +160,18 @@ describe('index', function() {
 
         fsMock.existsSync.returns(true);
 
-        fsSleep = {
+        sleepMock = {
             msleep: sinon.stub()
         };
 
-        fsSleep.msleep.returns(1);
+        sleepMock.msleep.returns(0);
 
         fsMock.readFileSync.withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token').returns('api_key');
         fsMock.readFileSync.withArgs(sinon.match(/config\/pod.yaml.hbs/)).returns(TEST_TIM_YAML);
 
         mockery.registerMock('fs', fsMock);
         mockery.registerMock('requestretry', requestRetryMock);
-        mockery.registerMock('sleep', fsSleep);
+        mockery.registerMock('sleep', sleepMock);
         /* eslint-disable global-require */
         Executor = require('../index');
         /* eslint-enable global-require */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,6 +39,7 @@ describe('index', function() {
     let Executor;
     let requestRetryMock;
     let fsMock;
+    let fsSleep;
     let executor;
     const testBuildId = 15;
     const testToken = 'abcdefg';
@@ -159,12 +160,18 @@ describe('index', function() {
 
         fsMock.existsSync.returns(true);
 
+        fsSleep = {
+            msleep: sinon.stub()
+        };
+
+        fsSleep.msleep.returns(1);
+
         fsMock.readFileSync.withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token').returns('api_key');
         fsMock.readFileSync.withArgs(sinon.match(/config\/pod.yaml.hbs/)).returns(TEST_TIM_YAML);
 
         mockery.registerMock('fs', fsMock);
         mockery.registerMock('requestretry', requestRetryMock);
-
+        mockery.registerMock('sleep', fsSleep);
         /* eslint-disable global-require */
         Executor = require('../index');
         /* eslint-enable global-require */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,8 +145,7 @@ describe('index', function() {
             kubernetes: {
                 nodeSelectors: {},
                 preferredNodeSelectors: {},
-                lifecycleHooks: {},
-                podStatusQueryDelay: 1
+                lifecycleHooks: {}
             },
             fusebox: { retry: { minTimeout: 1 } },
             prefix: 'beta_'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -730,7 +730,7 @@ describe('index', function() {
                     message: 'cannot get pod status'
                 }
             };
-            const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
+            const returnMessage = `Error: Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -753,7 +753,7 @@ describe('index', function() {
                     }
                 }
             };
-            const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
+            const returnMessage = `Error: Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2
@@ -791,7 +791,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -825,7 +825,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -859,7 +859,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -893,7 +893,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Error: Build failed to start. Please check if your image is valid.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -927,7 +927,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Error: Build failed to start. Please check if your image is valid.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -961,7 +961,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Error: Build failed to start. Please check if your image is valid.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -995,7 +995,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -1028,7 +1028,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
+            const returnMessage = `Error: Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2
@@ -1055,7 +1055,7 @@ describe('index', function() {
                     }
                 }
             };
-            const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
+            const returnMessage = `Error: Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -454,7 +454,7 @@ describe('index', function() {
         });
 
         it('successfully calls start', () => {
-            executor.start(fakeStartConfig).then(() => {
+            return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
                 assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,6 @@ describe('index', function() {
     let Executor;
     let requestRetryMock;
     let fsMock;
-    let sleepMock;
     let executor;
     const testBuildId = 15;
     const testToken = 'abcdefg';
@@ -146,7 +145,8 @@ describe('index', function() {
             kubernetes: {
                 nodeSelectors: {},
                 preferredNodeSelectors: {},
-                lifecycleHooks: {}
+                lifecycleHooks: {},
+                podStatusQueryDelay: 0
             },
             fusebox: { retry: { minTimeout: 1 } },
             prefix: 'beta_'
@@ -160,18 +160,11 @@ describe('index', function() {
 
         fsMock.existsSync.returns(true);
 
-        sleepMock = {
-            msleep: sinon.stub()
-        };
-
-        sleepMock.msleep.returns(0);
-
         fsMock.readFileSync.withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token').returns('api_key');
         fsMock.readFileSync.withArgs(sinon.match(/config\/pod.yaml.hbs/)).returns(TEST_TIM_YAML);
 
         mockery.registerMock('fs', fsMock);
         mockery.registerMock('requestretry', requestRetryMock);
-        mockery.registerMock('sleep', sleepMock);
         /* eslint-disable global-require */
         Executor = require('../index');
         /* eslint-enable global-require */
@@ -730,7 +723,7 @@ describe('index', function() {
                     message: 'cannot get pod status'
                 }
             };
-            const returnMessage = `Error: Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
+            const returnMessage = `Failed to get pod status:${JSON.stringify(returnResponse.body, null, 2)}`;
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -753,7 +746,7 @@ describe('index', function() {
                     }
                 }
             };
-            const returnMessage = `Error: Failed to create pod. Pod status is:${JSON.stringify(
+            const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2
@@ -791,7 +784,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -825,7 +818,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -859,7 +852,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -893,7 +886,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -927,7 +920,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -961,7 +954,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please check if your image is valid.';
+            const returnMessage = 'Build failed to start. Please check if your image is valid.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -995,7 +988,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = 'Error: Build failed to start. Please reach out to your cluster admin for help.';
+            const returnMessage = 'Build failed to start. Please reach out to your cluster admin for help.';
 
             requestRetryMock.withArgs(getConfig).yieldsAsync(null, returnResponse, returnResponse.body);
 
@@ -1028,7 +1021,7 @@ describe('index', function() {
                 }
             };
 
-            const returnMessage = `Error: Failed to create pod. Pod status is:${JSON.stringify(
+            const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2
@@ -1055,7 +1048,7 @@ describe('index', function() {
                     }
                 }
             };
-            const returnMessage = `Error: Failed to create pod. Pod status is:${JSON.stringify(
+            const returnMessage = `Failed to create pod. Pod status is:${JSON.stringify(
                 returnResponse.body.status,
                 null,
                 2

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,7 +146,7 @@ describe('index', function() {
                 nodeSelectors: {},
                 preferredNodeSelectors: {},
                 lifecycleHooks: {},
-                podStatusQueryDelay: 0
+                podStatusQueryDelay: 1
             },
             fusebox: { retry: { minTimeout: 1 } },
             prefix: 'beta_'
@@ -464,11 +464,11 @@ describe('index', function() {
         it('successfully calls start and update hostname and imagePullStartTime', () => {
             const dateNow = Date.now();
             const isoTime = new Date(dateNow).toISOString();
-            const sandbox = sinon.createSandbox({
-                useFakeTimers: false
+            const clock = sinon.useFakeTimers({
+                now: dateNow,
+                shouldAdvanceTime: true
             });
 
-            sandbox.useFakeTimers(dateNow);
             putConfig.body.stats = {
                 hostname: 'node1.my.k8s.cluster.com',
                 imagePullStartTime: isoTime
@@ -481,7 +481,7 @@ describe('index', function() {
                 assert.calledWith(requestRetryMock.thirdCall, putConfig);
                 getConfig.retryStrategy = executor.pendingStatusRetryStrategy;
                 assert.calledWith(requestRetryMock.lastCall, sinon.match(getConfig));
-                sandbox.restore();
+                clock.restore();
             });
         });
 


### PR DESCRIPTION
## Context

When pod is scheduled with invalid image or container without sudo permission it should fail consistently and update build status and message appropriately, but it works intermittently. 

## Objective

This could be due to delay in k8s updating pod status to failed. Move the pod response check to a consolidated function and enable k8s pod response payload logging to narrow down the root-cause. 

## References

https://github.com/screwdriver-cd/executor-k8s/pull/138
https://github.com/screwdriver-cd/executor-k8s/pull/139
https://github.com/screwdriver-cd/executor-k8s/pull/140

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
