### PR TITLE
feat: add temination grace period to config

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -12,6 +12,7 @@ spec:
   {{/if}}
   serviceAccountName: {{service_account}}
   automountServiceAccountToken: {{automount_service_account_token}}
+  terminationGracePeriodSeconds: {{termination_grace_period_seconds}}
   restartPolicy: Never
   dnsPolicy: {{dns_policy}}
   containers:

--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ class K8sExecutor extends Executor {
         this.serviceAccount = this.kubernetes.serviceAccount || 'default';
         this.dnsPolicy = this.kubernetes.dnsPolicy || 'ClusterFirst';
         this.automountServiceAccountToken = this.kubernetes.automountServiceAccountToken === 'true' || false;
-        this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 60;
+        this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 30;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
         this.retryDelay = this.requestretryOptions.retryDelay || DEFAULT_RETRYDELAY;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const DOCKER_CPU_RESOURCE = 'dockerCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
 const PR_JOBNAME_REGEX_PATTERN = /^PR-([0-9]+)(?::[\w-]+)?$/gi;
+const TERMINATION_GRACE_PERIOD_SECONDS = 'terminationGracePeriodSeconds';
 
 /**
  * Parses annotations config and update intended annotations
@@ -175,6 +176,7 @@ class K8sExecutor extends Executor {
      * @param  {Object}  [options.kubernetes.nodeSelectors]                      Object representing node label-value pairs
      * @param  {Object}  [options.kubernetes.lifecycleHooks]                     Object representing pod lifecycle hooks
      * @param  {Object}  [options.kubernetes.volumeMounts]                       Object representing pod volume mounts (e.g.: [ { "name": "kvm", "mountPath": "/dev/kvm", "path": "/dev/kvm/", "type": "File", "readOnly": true } ] )
+     * @param  {String}  [options.kubernetes.terminationGracePeriodSeconds]      TerminationGracePeriodSeconds setting for k8s pods
      * @param  {String}  [options.launchVersion=stable]                          Launcher container version to use
      * @param  {String}  [options.prefix='']                                     Prefix for job name
      * @param  {String}  [options.fusebox]                                       Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
@@ -213,6 +215,7 @@ class K8sExecutor extends Executor {
         this.serviceAccount = this.kubernetes.serviceAccount || 'default';
         this.dnsPolicy = this.kubernetes.dnsPolicy || 'ClusterFirst';
         this.automountServiceAccountToken = this.kubernetes.automountServiceAccountToken === 'true' || false;
+        this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 60;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
         this.breaker = new Fusebox(requestretry, options.fusebox);
         this.retryDelay = this.requestretryOptions.retryDelay || DEFAULT_RETRYDELAY;
@@ -326,6 +329,7 @@ class K8sExecutor extends Executor {
         const pipelineId = hoek.reach(config, 'pipeline.id', { default: '' });
         const jobName = hoek.reach(config, 'jobName', { default: '' });
         const annotations = this.parseAnnotations(hoek.reach(config, 'annotations', { default: {} }));
+
         const cpuValues = {
             MAX: this.maxCpu,
             TURBO: this.turboCpu,
@@ -399,6 +403,9 @@ class K8sExecutor extends Executor {
         }
 
         const buildContainerName = `${this.prefix}${buildId}`;
+        const terminationGracePeriod = annotations[TERMINATION_GRACE_PERIOD_SECONDS]
+            ? Math.max(annotations[TERMINATION_GRACE_PERIOD_SECONDS], this.terminationGracePeriodSeconds)
+            : this.terminationGracePeriodSeconds;
 
         const podTemplate = template({
             runtimeClass: this.runtimeClass,
@@ -434,6 +441,7 @@ class K8sExecutor extends Executor {
             },
             service_account: this.serviceAccount,
             automount_service_account_token: this.automountServiceAccountToken,
+            termination_grace_period_seconds: terminationGracePeriod,
             docker: {
                 enabled: DOCKER_ENABLED,
                 cpu: DOCKER_CPU,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -103,7 +103,7 @@ describe('index', function() {
         }
     };
     const testLifecycleHooksSpec = {
-        terminationGracePeriodSeconds: 60,
+        terminationGracePeriodSeconds: 30,
         containers: [
             {
                 name: 'beta_15',
@@ -241,7 +241,7 @@ describe('index', function() {
         executor = new Executor();
         assert.equal(executor.buildTimeout, DEFAULT_BUILD_TIMEOUT);
         assert.equal(executor.maxBuildTimeout, MAX_BUILD_TIMEOUT);
-        assert.equal(executor.terminationGracePeriodSeconds, 60);
+        assert.equal(executor.terminationGracePeriodSeconds, 30);
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
         assert.equal(executor.automountServiceAccountToken, false);
@@ -385,7 +385,7 @@ describe('index', function() {
                     },
                     spec: {
                         containers: [{ name: 'beta_15' }],
-                        terminationGracePeriodSeconds: 60
+                        terminationGracePeriodSeconds: 30
                     },
                     command: ['/opt/sd/launch http://api:8080 http://store:8080 abcdefg 90 15']
                 },
@@ -1195,7 +1195,7 @@ describe('index', function() {
         it('updates config with container lifecycle settings', () => {
             const updatedConfig = JSON.parse(JSON.stringify(fakeConfig));
 
-            fakeConfig.spec = { containers: [{ name: 'beta_15' }], terminationGracePeriodSeconds: 60 };
+            fakeConfig.spec = { containers: [{ name: 'beta_15' }], terminationGracePeriodSeconds: 30 };
             updatedConfig.spec = _.assign({}, updatedConfig.spec, testLifecycleHooksSpec);
 
             setLifecycleHooks(fakeConfig, lifecycleHooks, 'beta_15');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,7 @@ metadata:
   memory: {{memory}}
   dnsPolicy: {{dns_policy}}
 spec:
+  terminationGracePeriodSeconds: {{termination_grace_period_seconds}}
   containers:
   - name: beta_15
 command:
@@ -102,6 +103,7 @@ describe('index', function() {
         }
     };
     const testLifecycleHooksSpec = {
+        terminationGracePeriodSeconds: 60,
         containers: [
             {
                 name: 'beta_15',
@@ -194,6 +196,7 @@ describe('index', function() {
                 host: 'kubernetes2',
                 serviceAccount: 'foobar',
                 automountServiceAccountToken: 'true',
+                terminationGracePeriodSeconds: 30,
                 jobsNamespace: 'baz',
                 resources: {
                     cpu: {
@@ -230,6 +233,7 @@ describe('index', function() {
         assert.equal(executor.highMemory, 5);
         assert.equal(executor.lowMemory, 2);
         assert.equal(executor.microMemory, 1);
+        assert.equal(executor.terminationGracePeriodSeconds, 30);
     });
 
     it('allow empty options', () => {
@@ -237,6 +241,7 @@ describe('index', function() {
         executor = new Executor();
         assert.equal(executor.buildTimeout, DEFAULT_BUILD_TIMEOUT);
         assert.equal(executor.maxBuildTimeout, MAX_BUILD_TIMEOUT);
+        assert.equal(executor.terminationGracePeriodSeconds, 60);
         assert.equal(executor.launchVersion, 'stable');
         assert.equal(executor.serviceAccount, 'default');
         assert.equal(executor.automountServiceAccountToken, false);
@@ -379,7 +384,8 @@ describe('index', function() {
                         memory: 2
                     },
                     spec: {
-                        containers: [{ name: 'beta_15' }]
+                        containers: [{ name: 'beta_15' }],
+                        terminationGracePeriodSeconds: 60
                     },
                     command: ['/opt/sd/launch http://api:8080 http://store:8080 abcdefg 90 15']
                 },
@@ -582,6 +588,16 @@ describe('index', function() {
             postConfig.json.command = [
                 `/opt/sd/launch http://api:8080 http://store:8080 abcdefg ${MAX_BUILD_TIMEOUT} 15`
             ];
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
+
+        it('sets the terminationGracePeriodSeconds appropriately when annotation is set', () => {
+            postConfig.json.spec.terminationGracePeriodSeconds = 90;
+            fakeStartConfig.annotations['screwdriver.cd/terminationGracePeriodSeconds'] = 90;
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -1179,7 +1195,7 @@ describe('index', function() {
         it('updates config with container lifecycle settings', () => {
             const updatedConfig = JSON.parse(JSON.stringify(fakeConfig));
 
-            fakeConfig.spec = { containers: [{ name: 'beta_15' }] };
+            fakeConfig.spec = { containers: [{ name: 'beta_15' }], terminationGracePeriodSeconds: 60 };
             updatedConfig.spec = _.assign({}, updatedConfig.spec, testLifecycleHooksSpec);
 
             setLifecycleHooks(fakeConfig, lifecycleHooks, 'beta_15');


### PR DESCRIPTION
## Context

Currently if a build is aborted the teardown steps don't run and hence generated artifacts are not available in this case, so we need to increase the grace period before pod termination to run the artifact saving steps

## Objective

This PR adds provision to increase pod timeout by using annotations

## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
