### PR TITLE
feat(1125): add terminationgraceperiod env var

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -30,6 +30,8 @@ spec:
         value: {{runtimeClass}}
       - name: SD_PUSHGATEWAY_URL
         value: {{pushgateway_url}}
+      - name: SD_TERMINATION_GRACE_PERIOD_SECONDS
+        value: {{termination_grace_period_seconds}}
       - name: CONTAINER_IMAGE
         value: {{container}}
       - name: SD_PIPELINE_ID


### PR DESCRIPTION
## Context

Currently if a build is aborted the teardown steps don't run and hence generated artifacts are not available in this case, so we need to increase the grace period before pod termination to run the artifact saving steps

## Objective

This PR adds pod timeout configuration to env var
## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
