### PR TITLE
feat(2265): Allow custom pod labels [2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The class provides a couple options that are configurable in the instantiation o
 | config.launchImage | String | 'screwdrivercd/launcher' | Launcher image to use |
 | config.launchVersion | String | 'stable' | Launcher container version to use (stable) |
 | config.prefix | String | '' | Prefix to container names ("") |
+| config.kubernetes.dnsPolicy | String | 'ClusterFirst' | DNS Policy for build pod |
+| config.kubernetes.imagePullPolicy | String | 'Always' | Image Pull Policy for build pod |
 | config.kubernetes.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |
 | config.kubernetes.nodeSelectors | Object | {} | Object representing node label-value pairs |
 | config.kubernetes.preferredNodeSelectors | Object | {} | Object representing preferred node label-value pairs |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The class provides a couple options that are configurable in the instantiation o
 | config.launchVersion | String | 'stable' | Launcher container version to use (stable) |
 | config.prefix | String | '' | Prefix to container names ("") |
 | config.kubernetes.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |
+| config.kubernetes.nodeSelectors | Object | {} | Object representing node label-value pairs |
+| config.kubernetes.preferredNodeSelectors | Object | {} | Object representing preferred node label-value pairs |
+| config.kubernetes.podLabels | Object | { app: 'screwdriver', tier: 'builds', sdbuild: buildContainerName } | Object representing custom pod label key-value pairs |
 | config.kubernetes.resources.memory.turbo | Number | 16 | Value for TURBO memory (in GB) |
 | config.kubernetes.resources.memory.high | Number | 12 | Value for HIGH memory (in GB) |
 | config.kubernetes.resources.memory.low | Number | 2 | Value for LOW memory (in GB) |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.prefix | String | '' | Prefix to container names ("") |
 | config.kubernetes.dnsPolicy | String | 'ClusterFirst' | DNS Policy for build pod |
 | config.kubernetes.imagePullPolicy | String | 'Always' | Image Pull Policy for build pod |
+} config.kubernetes.imagePullSecretName | String | '' | Name of image pull secret |
 | config.kubernetes.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |
 | config.kubernetes.nodeSelectors | Object | {} | Object representing node label-value pairs |
 | config.kubernetes.preferredNodeSelectors | Object | {} | Object representing preferred node label-value pairs |
@@ -39,6 +40,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.kubernetes.resources.cpu.high | Number | 6 | Value for HIGH CPU (in cores) |
 | config.kubernetes.resources.cpu.low | Number | 2 | Value for LOW CPU (in cores) |
 | config.kubernetes.resources.cpu.micro | Number | 0.5 | Value for MICRO CPU (in cores) |
+| config.kubernetes.runtimeClass | String | '' | Runtime class |
 
 
 ### Methods

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -2,10 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{pod_name}}"
-  labels:
-    sdbuild: "{{build_id_with_prefix}}"
-    app: screwdriver
-    tier: builds
 spec:
   {{#if runtimeClass}}
   runtimeClassName: {{runtimeClass}}

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -14,7 +14,7 @@ spec:
   containers:
   - name: "{{build_id_with_prefix}}"
     image: {{container}}
-    imagePullPolicy: Always
+    imagePullPolicy: {{image_pull_policy}}
     securityContext:
       privileged: {{privileged}}
     resources:

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -11,6 +11,10 @@ spec:
   terminationGracePeriodSeconds: {{termination_grace_period_seconds}}
   restartPolicy: Never
   dnsPolicy: {{dns_policy}}
+  {{#if imagePullSecretName}}
+  imagePullSecrets:
+  - name: {{imagePullSecretName}}
+  {{/if}}
   containers:
   - name: "{{build_id_with_prefix}}"
     image: {{container}}

--- a/index.js
+++ b/index.js
@@ -178,6 +178,7 @@ class K8sExecutor extends Executor {
      * @param  {Number}  [options.kubernetes.maxBuildTimeout=120]                Max timeout user can configure up to
      * @param  {String}  [options.kubernetes.serviceAccount=default]             Service Account for builds
      * @param  {String}  [options.kubernetes.dnsPolicy=ClusterFirst]             DNS Policy for build pod
+     * @param  {String}  [options.kubernetes.imagePullPolicy=Always]             Image Pull Policy for build pod
      * @param  {String}  [options.kubernetes.resources.cpu.max=12]               Upper bound for custom CPU value (in cores)
      * @param  {String}  [options.kubernetes.resources.cpu.turbo=12]             Value for TURBO CPU (in cores)
      * @param  {String}  [options.kubernetes.resources.cpu.high=6]               Value for HIGH CPU (in cores)
@@ -236,6 +237,7 @@ class K8sExecutor extends Executor {
         this.maxBuildTimeout = this.kubernetes.maxBuildTimeout || MAX_BUILD_TIMEOUT;
         this.serviceAccount = this.kubernetes.serviceAccount || 'default';
         this.dnsPolicy = this.kubernetes.dnsPolicy || 'ClusterFirst';
+        this.imagePullPolicy = this.kubernetes.imagePullPolicy || 'Always';
         this.automountServiceAccountToken = this.kubernetes.automountServiceAccountToken === 'true' || false;
         this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 30;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
@@ -510,6 +512,7 @@ class K8sExecutor extends Executor {
                 memory: DOCKER_RAM
             },
             dns_policy: this.dnsPolicy,
+            image_pull_policy: this.imagePullPolicy,
             volume_mounts: this.volumeMounts
         });
         const podConfig = yaml.safeLoad(podTemplate);

--- a/index.js
+++ b/index.js
@@ -200,6 +200,8 @@ class K8sExecutor extends Executor {
      * @param  {Object}  [options.kubernetes.volumeMounts]                       Object representing pod volume mounts (e.g.: [ { "name": "kvm", "mountPath": "/dev/kvm", "path": "/dev/kvm/", "type": "File", "readOnly": true } ] )
      * @param  {String}  [options.kubernetes.terminationGracePeriodSeconds]      TerminationGracePeriodSeconds setting for k8s pods
      * @param  {Number}  [options.kubernetes.podStatusQueryDelay]                Number of milliseconds to wait before calling k8s pod query status for pending retry strategy
+     * @param  {String}  [options.kubernetes.runtimeClass='']                    Runtime class
+     * @param  {String}  [options.kubernetes.imagePullSecretName='']             Name of image pull secret
      * @param  {String}  [options.launchVersion=stable]                          Launcher container version to use
      * @param  {String}  [options.prefix='']                                     Prefix for job name
      * @param  {String}  [options.fusebox]                                       Options for the circuit breaker (https://github.com/screwdriver-cd/circuit-fuses)
@@ -228,6 +230,7 @@ class K8sExecutor extends Executor {
         }
         this.host = this.kubernetes.host || 'kubernetes.default';
         this.runtimeClass = this.kubernetes.runtimeClass || '';
+        this.imagePullSecretName = this.kubernetes.imagePullSecretName || '';
         this.launchImage = options.launchImage || 'screwdrivercd/launcher';
         this.launchVersion = options.launchVersion || 'stable';
         this.prefix = options.prefix || '';
@@ -473,6 +476,7 @@ class K8sExecutor extends Executor {
 
         const podTemplate = template({
             runtimeClass: this.runtimeClass,
+            imagePullSecretName: this.imagePullSecretName,
             cpu,
             memory,
             pod_name: `${buildContainerName}-${random}`,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,6 +21,7 @@ metadata:
   cpu: {{cpu}}
   memory: {{memory}}
   dnsPolicy: {{dns_policy}}
+  imagePullPolicy: {{image_pull_policy}}
 spec:
   terminationGracePeriodSeconds: {{termination_grace_period_seconds}}
   containers:
@@ -387,6 +388,7 @@ describe('index', function() {
                         serviceAccount: testServiceAccount,
                         cpu: 2000,
                         dnsPolicy: 'ClusterFirst',
+                        imagePullPolicy: 'Always',
                         memory: 2,
                         labels: { app: 'screwdriver', sdbuild: 'beta_15', tier: 'builds' }
                     },
@@ -513,6 +515,20 @@ describe('index', function() {
             postConfig.json.metadata.dnsPolicy = 'Default';
 
             executorOptions.kubernetes.dnsPolicy = 'Default';
+
+            executor = new Executor(executorOptions);
+
+            return executor.start(fakeStartConfig).then(() => {
+                assert.calledWith(requestRetryMock.firstCall, postConfig);
+                delete getConfig.retryStrategy;
+                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
+            });
+        });
+
+        it('sets proper Image Pull policy required by cluster admin', () => {
+            postConfig.json.metadata.imagePullPolicy = 'IfNotPresent';
+
+            executorOptions.kubernetes.imagePullPolicy = 'IfNotPresent';
 
             executor = new Executor(executorOptions);
 


### PR DESCRIPTION
## Context

Cluster admins might want to configure custom pod labels.

## Objective

This PR moves labels logic to the index.
Also adds config:
- to allow for custom pod labels (and will set default pod labels and custom ones accordingly)
- to set imagePullPolicy
- to configure imagePullSecrets name

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2265

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
