### PR TITLE
feat: add dlc flag and path to pod yaml

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -117,6 +117,10 @@ spec:
     - mountPath: /opt/sdeventcache
       name: sd-event-cache
     {{/if}}
+    {{#if cache.dlcEnabled}}
+    - mountPath: {{cache.dlc_mount_path}}
+      name: sd-docker-cache
+    {{/if}}
   volumes:
     - name: screwdriver
       type: DirectoryOrCreate
@@ -145,6 +149,12 @@ spec:
       type: DirectoryOrCreate
       hostPath:
         path: {{cache.path}}/events/{{pipeline_id}}/{{event_id}}
+    {{/if}}
+    {{#if cache.dlcEnabled}}
+     - name: sd-docker-cache
+      type: DirectoryOrCreate
+      hostPath:
+        path: {{cache.dlc_path}}/pipelines/{{pipeline_id}}/{{cache.dlc_mount_path}}
     {{/if}}
     {{#each volume_mounts}}
     - name: {{this.name}}

--- a/index.js
+++ b/index.js
@@ -302,6 +302,9 @@ class K8sExecutor extends Executor {
                     waitingReason !== 'StartError')
             );
         };
+        this.dlcEnabled = hoek.reach(options, 'kubernetes.dlcEnabled', { default: false });
+        this.dlcPath = hoek.reach(options, 'kubernetes.dlcPath');
+        this.dlcMountPath = hoek.reach(options, 'kubernetes.dlcMountPath');
     }
 
     /**
@@ -508,7 +511,10 @@ class K8sExecutor extends Executor {
                 md5check: this.cacheMd5Check,
                 max_size_mb: this.cacheMaxSizeInMB,
                 max_go_threads: this.cacheMaxGoThreads,
-                volumeReadOnly
+                volumeReadOnly,
+                dlc_enabled: this.dlcEnabled || config.dlc,
+                dlc_path: this.dlcPath,
+                dlc_mount_path: this.dlcMountPath
             },
             service_account: this.serviceAccount,
             automount_service_account_token: this.automountServiceAccountToken,


### PR DESCRIPTION
## Context

SD needs to support docker layer cache natively for builds

## Objective

This PR adds configurable dlc flag and path to executor

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
