### PR TITLE
feat: Add downwardAPI labels, annotations to pod

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -63,6 +63,7 @@ spec:
     volumeMounts:
     - name: podinfo
       mountPath: /etc/podinfo
+      readOnly: true
     - mountPath: /opt/sd
       name: screwdriver
       readOnly: true

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -61,6 +61,8 @@ spec:
       /opt/sd/run.sh "{{token}}" "{{api_uri}}" "{{store_uri}}" "{{build_timeout}}" "{{build_id}}" "{{ui_uri}}"
     {{/if}}
     volumeMounts:
+    - name: podinfo
+      mountPath: /etc/podinfo
     - mountPath: /opt/sd
       name: screwdriver
       readOnly: true
@@ -118,6 +120,15 @@ spec:
       name: sd-event-cache
     {{/if}}
   volumes:
+    - name: podinfo
+      downwardAPI:
+        items:
+          - path: "labels"
+            fieldRef:
+              fieldPath: metadata.labels
+          - path: "annotations"
+            fieldRef:
+              fieldPath: metadata.annotations
     - name: screwdriver
       type: DirectoryOrCreate
       hostPath:


### PR DESCRIPTION
## Context

We need to expose pod labels metadata to the container to display information

## Objective

This PR uses K8s downwardAPI to mount the labels and annotations to the container as volume

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
