### PR TITLE
feat: more refactor and add retry on pod status

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,10 +308,10 @@ class K8sExecutor extends Executor {
      * check build pod response
      * @method checkPodResponse
      * @param {Object}      resp    pod response object
-     * @param {String}      buidlId  buildId
+     * @param {String}      buildId  buildId
      */
-    checkPodResponse(resp, buidlId) {
-        logger.debug(`Build ${buidlId} pod response: ${JSON.stringify(resp, null, 2)}`);
+    checkPodResponse(resp, buildId) {
+        logger.debug(`Build ${buildId} pod response: ${JSON.stringify(resp, null, 2)}`);
 
         if (resp.statusCode !== 200) {
             throw new Error(`Failed to get pod status:${JSON.stringify(resp.body, null, 2)}`);

--- a/index.js
+++ b/index.js
@@ -320,8 +320,8 @@ class K8sExecutor extends Executor {
         const status = resp.body.status.phase.toLowerCase();
         const waitingReason = hoek.reach(resp.body, CONTAINER_WAITING_REASON_PATH);
 
-        logger.info(`Build ${buidlId} pod status: ${status}`);
-        logger.info(`Build ${buidlId} container waiting reason: ${waitingReason}`);
+        logger.info(`Build ${buildId} pod status: ${status}`);
+        logger.info(`Build ${buildId} container waiting reason: ${waitingReason}`);
 
         if (status === 'failed' || status === 'unknown') {
             throw new Error(`Failed to create pod. Pod status is: ${status}`);

--- a/index.js
+++ b/index.js
@@ -298,8 +298,7 @@ class K8sExecutor extends Executor {
                 'ErrImagePull',
                 'ImagePullBackOff',
                 'InvalidImageName',
-                'StartErr',
-                'StartErr'
+                'StartError'
             ];
 
             return err || !status || (status.toLowerCase() === 'pending' && !errorStatusList.includes(waitingReason));

--- a/index.js
+++ b/index.js
@@ -311,12 +311,13 @@ class K8sExecutor extends Executor {
      * @method checkPodResponse
      * @param {String}      config.status    the pod status
      * @param {String}      config.waitingReason    the pod waitigng reason
-     * @param {String}      config.buildId  buildId
+     * @param {String}      config.buildId  buildId the build id
+     * @param {String}      config.podName  podName the name of the pod
      * @return {Boolean}   isPodInitializing
      */
-    checkPodResponse({ status, waitingReason, buildId }) {
-        logger.info(`Build ${buildId} pod status: ${status}`);
-        logger.info(`Build ${buildId} container waiting reason: ${waitingReason}`);
+    checkPodResponse({ status, waitingReason, buildId, podName }) {
+        logger.info(`Build ${buildId}, podName: ${podName} and status: ${status} `);
+        logger.info(`Build ${buildId}, podName: ${podName} and container waiting reason: ${waitingReason}`);
 
         if (status === 'failed' || status === 'unknown') {
             throw new Error(`Failed to create pod. Pod status is: ${status}`);
@@ -409,7 +410,7 @@ class K8sExecutor extends Executor {
                 buildId,
                 retryStrategyFn: this.scheduleStatusRetryStrategy
             });
-            const isPodInitializing = this.checkPodResponse({ status, waitingReason, buildId });
+            const isPodInitializing = this.checkPodResponse({ status, waitingReason, buildId, podName });
             const updateConfig = {
                 apiUri: this.ecosystem.api,
                 buildId,
@@ -471,7 +472,7 @@ class K8sExecutor extends Executor {
      *
      * @param {String} config.podName the pod name
      * @param {String} config.buildId the build id
-     * @param {Function} config.retryStrategyFn
+     * @param {Function} config.retryStrategyFn fn to define retry logic
      * @returns {Object} the status and pod waiting reason
      */
     async getPodStatus({ podName, buildId, retryStrategyFn }) {


### PR DESCRIPTION
## Context

The build worker fails to get the current pod status and finishes the processing thereby leaving build in a hang state

## Objective

This PR adds a retry to the pod status query when the pod state is pending

## References

## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
