### PR TITLE
feat: add retry queue to address pending builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
+    "amqp-connection-manager": "^3.2.2",
+    "amqplib": "^0.8.0",
     "circuit-fuses": "^4.0.3",
     "handlebars": "^4.7.6",
     "js-yaml": "^3.11.0",


### PR DESCRIPTION
## Context

Pending builds with status like PodInitializing, ImagePullBackOff etc need to be addressed separately without affecting the processing time of builds

## Objective

This PR addresses the pending builds and adds a method to push to a retry queue. Which will process and take care of stopping rouge builds

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
