### PR TITLE
feat: add verify method in executor to check pod status

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The class provides a couple options that are configurable in the instantiation o
 
 ### Methods
 
-For more information on `start`, `stop`, and `stats` please see the [executor-base-class].
+For more information on `start`, `stop`, `verify` and `stats` please see the [executor-base-class].
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The class provides a couple options that are configurable in the instantiation o
 | config.prefix | String | '' | Prefix to container names ("") |
 | config.kubernetes.dnsPolicy | String | 'ClusterFirst' | DNS Policy for build pod |
 | config.kubernetes.imagePullPolicy | String | 'Always' | Image Pull Policy for build pod |
-} config.kubernetes.imagePullSecretName | String | '' | Name of image pull secret |
+| config.kubernetes.imagePullSecretName | String | '' | Name of image pull secret |
 | config.kubernetes.jobsNamespace | String | 'default' | Kubernetes namespace where builds are running on |
 | config.kubernetes.nodeSelectors | Object | {} | Object representing node label-value pairs |
 | config.kubernetes.preferredNodeSelectors | Object | {} | Object representing preferred node label-value pairs |

--- a/index.js
+++ b/index.js
@@ -411,9 +411,9 @@ class K8sExecutor extends Executor {
             throw new Error(`Failed to get pod status:${JSON.stringify(resp.body)}`);
         }
 
-        const nodeName = resp.body.spec && resp.body.spec.nodeName;
-        const responsePodName = resp.body.metadata.name;
-        const status = resp.body.status.phase.toLowerCase();
+        const nodeName = hoek.reach(resp, 'body.spec.nodeName');
+        const responsePodName = hoek.reach(resp, 'metadata.name');
+        const status = hoek.reach(resp, 'body.status.phase').toLowerCase();
 
         logger.info(`BuilId:${buildId}, status:${status}, podName:${responsePodName}`);
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
+    "amqp-connection-manager": "^3.2.2",
+    "amqplib": "^0.8.0",
     "circuit-fuses": "^4.0.3",
     "handlebars": "^4.7.6",
     "js-yaml": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "amqp-connection-manager": "^3.2.2",
-    "amqplib": "^0.8.0",
     "circuit-fuses": "^4.0.3",
     "handlebars": "^4.7.6",
     "js-yaml": "^3.11.0",


### PR DESCRIPTION
## Context

Pending builds with status like PodInitializing, ImagePullBackOff, etc need to be addressed separately without affecting the processing time of builds

## Objective

This PR adds implementation of *verify* method to the executor to check for pod health
## References
https://github.com/screwdriver-cd/screwdriver/issues/2491
https://github.com/screwdriver-cd/executor-k8s/pull/160
https://github.com/screwdriver-cd/executor-k8s/pull/161

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
