### PR TITLE
feat(1961): Use screwdriver-request package

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,10 +325,7 @@ class K8sExecutor extends Executor {
                 limit: this.maxAttempts,
                 calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
             },
-            json: {},
-            context: {
-                caller: 'updateBuild'
-            }
+            json: {}
         };
 
         if (statusMessage) {
@@ -365,10 +362,7 @@ class K8sExecutor extends Executor {
             headers: {
                 Authorization: `Bearer ${this.token}`
             },
-            https: { rejectUnauthorized: false },
-            context: {
-                caller: '_start'
-            }
+            https: { rejectUnauthorized: false }
         };
 
         try {
@@ -423,9 +417,6 @@ class K8sExecutor extends Executor {
             },
             hooks: {
                 afterResponse: [this.scheduleStatusRetryStrategy]
-            },
-            context: {
-                caller: 'getPodStatus'
             }
         };
 
@@ -633,10 +624,7 @@ class K8sExecutor extends Executor {
             headers: {
                 Authorization: `Bearer ${this.token}`
             },
-            https: { rejectUnauthorized: false },
-            context: {
-                caller: '_stop'
-            }
+            https: { rejectUnauthorized: false }
         };
 
         try {
@@ -736,9 +724,6 @@ class K8sExecutor extends Executor {
             },
             searchParams: {
                 labelSelector: `sdbuild=${this.prefix}${buildId}`
-            },
-            context: {
-                caller: 'getPods'
             }
         };
         const resp = await this.breaker.runCommand(statusOptions); // list of pods

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const hoek = require('@hapi/hoek');
 const path = require('path');
 const randomstring = require('randomstring');
-const requestretry = require('requestretry');
+const request = require('screwdriver-request');
 const handlebars = require('handlebars');
 const yaml = require('js-yaml');
 const _ = require('lodash');
@@ -246,7 +246,7 @@ class K8sExecutor extends Executor {
         this.automountServiceAccountToken = this.kubernetes.automountServiceAccountToken === 'true' || false;
         this.terminationGracePeriodSeconds = this.kubernetes.terminationGracePeriodSeconds || 30;
         this.podsUrl = `https://${this.host}/api/v1/namespaces/${this.jobsNamespace}/pods`;
-        this.breaker = new Fusebox(requestretry, options.fusebox);
+        this.breaker = new Fusebox(request, options.fusebox);
         this.retryDelay = this.requestretryOptions.retryDelay || DEFAULT_RETRYDELAY;
         this.maxAttempts = this.requestretryOptions.maxAttempts || DEFAULT_MAXATTEMPTS;
         this.maxCpu = hoek.reach(options, 'kubernetes.resources.cpu.max', { default: 12 });
@@ -276,8 +276,8 @@ class K8sExecutor extends Executor {
         this.annotations = hoek.reach(options, 'kubernetes.annotations');
         this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });
         this.secrets = hoek.reach(options, 'kubernetes.buildSecrets', { default: {} });
-        this.scheduleStatusRetryStrategy = (err, response, body) => {
-            const conditions = hoek.reach(body, 'status.conditions');
+        this.scheduleStatusRetryStrategy = (response, retryWithMergedOptions) => {
+            const conditions = hoek.reach(response, 'body.status.conditions');
             let scheduled = false;
 
             if (conditions) {
@@ -286,12 +286,20 @@ class K8sExecutor extends Executor {
                 scheduled = String(scheduledStatus) === 'True';
             }
 
-            return err || !scheduled;
-        };
-        this.pendingStatusRetryStrategy = (err, response, body) => {
-            const status = hoek.reach(body, 'status.phase');
+            if (!scheduled) {
+                retryWithMergedOptions({});
+            }
 
-            return err || !status || status.toLowerCase() === 'pending';
+            return response;
+        };
+        this.pendingStatusRetryStrategy = (response, retryWithMergedOptions) => {
+            const status = hoek.reach(response, 'body.status.phase');
+
+            if (!status || status.toLowerCase() === 'pending') {
+                retryWithMergedOptions({});
+            }
+
+            return response;
         };
     }
 
@@ -309,22 +317,26 @@ class K8sExecutor extends Executor {
     updateBuild(config) {
         const { apiUri, buildId, statusMessage, token, stats } = config;
         const options = {
-            json: true,
             method: 'PUT',
-            uri: `${apiUri}/v4/builds/${buildId}`,
+            url: `${apiUri}/v4/builds/${buildId}`,
             headers: { Authorization: `Bearer ${token}` },
-            strictSSL: false,
-            maxAttempts: this.maxAttempts,
-            retryDelay: this.retryDelay,
-            body: {}
+            rejectUnauthorized: false,
+            retry: {
+                limit: this.maxAttempts,
+                calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
+            },
+            json: {},
+            context: {
+                caller: 'updateBuild'
+            }
         };
 
         if (statusMessage) {
-            options.body.statusMessage = statusMessage;
+            options.json.statusMessage = statusMessage;
         }
 
         if (stats) {
-            options.body.stats = stats;
+            options.json.stats = stats;
         }
 
         return this.breaker.runCommand(options);
@@ -347,13 +359,16 @@ class K8sExecutor extends Executor {
         const { buildId, token } = config;
         const podConfig = this.createPodConfig(config);
         const options = {
-            uri: this.podsUrl,
+            url: this.podsUrl,
             method: 'POST',
             json: podConfig,
             headers: {
                 Authorization: `Bearer ${this.token}`
             },
-            strictSSL: false
+            rejectUnauthorized: false,
+            context: {
+                caller: '_start'
+            }
         };
 
         try {
@@ -398,15 +413,22 @@ class K8sExecutor extends Executor {
         logger.info(`Get pod status for ${podName} and buildId: ${buildId}`);
 
         const statusOptions = {
-            uri: `${this.podsUrl}/${podName}/status`,
+            url: `${this.podsUrl}/${podName}/status`,
             method: 'GET',
             headers: { Authorization: `Bearer ${this.token}` },
-            strictSSL: false,
-            maxAttempts: this.maxAttempts,
-            retryDelay: this.retryDelay,
-            retryStrategy: this.scheduleStatusRetryStrategy,
-            json: true
+            rejectUnauthorized: false,
+            retry: {
+                limit: this.maxAttempts,
+                calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
+            },
+            hooks: {
+                afterResponse: [this.scheduleStatusRetryStrategy]
+            },
+            context: {
+                caller: 'getPodStatus'
+            }
         };
+
         const resp = await this.breaker.runCommand(statusOptions);
 
         logger.debug(`Build ${buildId} pod response: ${JSON.stringify(resp.body)}`);
@@ -603,15 +625,18 @@ class K8sExecutor extends Executor {
      */
     async _stop(config) {
         const options = {
-            uri: this.podsUrl,
+            url: this.podsUrl,
             method: 'DELETE',
-            qs: {
+            searchParams: {
                 labelSelector: `sdbuild=${this.prefix}${config.buildId}`
             },
             headers: {
                 Authorization: `Bearer ${this.token}`
             },
-            strictSSL: false
+            rejectUnauthorized: false,
+            context: {
+                caller: '_stop'
+            }
         };
 
         try {
@@ -698,16 +723,22 @@ class K8sExecutor extends Executor {
         logger.info(`Get pod status for and buildId: ${buildId}`);
 
         const statusOptions = {
-            uri: this.podsUrl,
+            url: this.podsUrl,
             method: 'GET',
             headers: { Authorization: `Bearer ${this.token}` },
-            strictSSL: false,
-            maxAttempts: this.maxAttempts,
-            retryDelay: this.retryDelay,
-            retryStrategy: this.pendingStatusRetryStrategy,
-            json: true,
-            qs: {
+            rejectUnauthorized: false,
+            retry: {
+                limit: this.maxAttempts,
+                calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
+            },
+            hooks: {
+                afterResponse: [this.pendingStatusRetryStrategy]
+            },
+            searchParams: {
                 labelSelector: `sdbuild=${this.prefix}${buildId}`
+            },
+            context: {
+                caller: 'getPods'
             }
         };
         const resp = await this.breaker.runCommand(statusOptions); // list of pods

--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ class K8sExecutor extends Executor {
             method: 'PUT',
             url: `${apiUri}/v4/builds/${buildId}`,
             headers: { Authorization: `Bearer ${token}` },
-            rejectUnauthorized: false,
+            https: { rejectUnauthorized: false },
             retry: {
                 limit: this.maxAttempts,
                 calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
@@ -365,7 +365,7 @@ class K8sExecutor extends Executor {
             headers: {
                 Authorization: `Bearer ${this.token}`
             },
-            rejectUnauthorized: false,
+            https: { rejectUnauthorized: false },
             context: {
                 caller: '_start'
             }
@@ -416,7 +416,7 @@ class K8sExecutor extends Executor {
             url: `${this.podsUrl}/${podName}/status`,
             method: 'GET',
             headers: { Authorization: `Bearer ${this.token}` },
-            rejectUnauthorized: false,
+            https: { rejectUnauthorized: false },
             retry: {
                 limit: this.maxAttempts,
                 calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
@@ -633,7 +633,7 @@ class K8sExecutor extends Executor {
             headers: {
                 Authorization: `Bearer ${this.token}`
             },
-            rejectUnauthorized: false,
+            https: { rejectUnauthorized: false },
             context: {
                 caller: '_stop'
             }
@@ -726,7 +726,7 @@ class K8sExecutor extends Executor {
             url: this.podsUrl,
             method: 'GET',
             headers: { Authorization: `Bearer ${this.token}` },
-            rejectUnauthorized: false,
+            https: { rejectUnauthorized: false },
             retry: {
                 limit: this.maxAttempts,
                 calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^7.7.0",
-    "eslint-config-screwdriver": "^5.0.4",
-    "mocha": "^8.2.1",
+    "eslint": "^7.32.0",
+    "eslint-config-screwdriver": "^5.0.7",
+    "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mockery": "^2.0.0",
@@ -51,18 +51,19 @@
     "sinon": "^5.0.10"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.0.4",
-    "circuit-fuses": "^4.0.3",
-    "handlebars": "^4.7.6",
-    "js-yaml": "^3.11.0",
+    "@hapi/hoek": "^9.2.0",
+    "circuit-fuses": "^4.1.0",
+    "handlebars": "^4.7.7",
+    "js-yaml": "^3.14.1",
     "jsonwebtoken": "^8.5.1",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "node-gyp": "^7.1.2",
-    "randomstring": "^1.1.5",
+    "randomstring": "^1.2.1",
     "request": "^2.88.0",
     "requestretry": "^4.0.0",
-    "screwdriver-executor-base": "^8.0.0",
-    "screwdriver-logger": "^1.0.1",
+    "screwdriver-executor-base": "^8.4.0",
+    "screwdriver-logger": "^1.1.0",
+    "screwdriver-request": "^1.0.2",
     "tinytim": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -302,7 +302,7 @@ describe('index', function() {
             headers: {
                 Authorization: 'Bearer api_key'
             },
-            rejectUnauthorized: false,
+            https: { rejectUnauthorized: false },
             context: {
                 caller: '_stop'
             }
@@ -317,8 +317,7 @@ describe('index', function() {
                 .stop({
                     buildId: testBuildId
                 })
-                .then(res => {
-                    console.log('res: ', res);
+                .then(() => {
                     assert.calledWith(requestRetryMock, deleteConfig);
                     assert.calledOnce(requestRetryMock);
                 }));
@@ -404,7 +403,7 @@ describe('index', function() {
                 headers: {
                     Authorization: 'Bearer api_key'
                 },
-                rejectUnauthorized: false,
+                https: { rejectUnauthorized: false },
                 context: {
                     caller: '_start'
                 }
@@ -415,7 +414,7 @@ describe('index', function() {
                 headers: {
                     Authorization: 'Bearer api_key'
                 },
-                rejectUnauthorized: false,
+                https: { rejectUnauthorized: false },
                 context: {
                     caller: 'getPodStatus'
                 },
@@ -431,7 +430,7 @@ describe('index', function() {
                     Authorization: `Bearer ${testToken}`
                 },
                 json: {},
-                rejectUnauthorized: false,
+                https: { rejectUnauthorized: false },
                 context: {
                     caller: 'updateBuild'
                 },
@@ -1147,7 +1146,7 @@ describe('index', function() {
                 headers: {
                     Authorization: 'Bearer api_key'
                 },
-                rejectUnauthorized: false,
+                https: { rejectUnauthorized: false },
                 hooks: { afterResponse: [executor.pendingStatusRetryStrategy] },
                 retry: { limit: MAXATTEMPTS },
                 searchParams: {
@@ -1499,8 +1498,6 @@ describe('index', function() {
 
                 assert.equal(expectedMessage, actualMessage);
             } catch (error) {
-                console.log(error);
-
                 throw new Error('should not fail');
             }
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -302,10 +302,7 @@ describe('index', function() {
             headers: {
                 Authorization: 'Bearer api_key'
             },
-            https: { rejectUnauthorized: false },
-            context: {
-                caller: '_stop'
-            }
+            https: { rejectUnauthorized: false }
         };
 
         beforeEach(() => {
@@ -403,10 +400,7 @@ describe('index', function() {
                 headers: {
                     Authorization: 'Bearer api_key'
                 },
-                https: { rejectUnauthorized: false },
-                context: {
-                    caller: '_start'
-                }
+                https: { rejectUnauthorized: false }
             };
             getConfig = {
                 url: `${podsUrl}/testpod/status`,
@@ -415,9 +409,6 @@ describe('index', function() {
                     Authorization: 'Bearer api_key'
                 },
                 https: { rejectUnauthorized: false },
-                context: {
-                    caller: 'getPodStatus'
-                },
                 retry: {
                     limit: MAXATTEMPTS
                 },
@@ -431,9 +422,6 @@ describe('index', function() {
                 },
                 json: {},
                 https: { rejectUnauthorized: false },
-                context: {
-                    caller: 'updateBuild'
-                },
                 retry: {
                     limit: MAXATTEMPTS
                 }


### PR DESCRIPTION
## Context

It would be nice to replace deprecated request/requestretry package with a different one.

## Objective

This PR attempts to replace [requestretry package](https://www.npmjs.com/package/requestretry) with [got package](https://github.com/sindresorhus/got).

*Note: got package will only retry on these statusCodes: https://github.com/sindresorhus/got/blob/main/source/core/options.ts#L616-L627*

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.