### PR TITLE
feat: update dind image to 20.10

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -94,7 +94,7 @@ spec:
     {{/each}}
   {{#if docker.enabled}}
   - name: dind
-    image: docker:18.05-dind
+    image: docker:20.10-dind
     resources:
       limits:
         cpu: {{docker.cpu }}m


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The dind image for build pod seems to be outdated.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
update image tag to `20.10-dind`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- [Docker - Official Image | Docker Hub](https://hub.docker.com/_/docker)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
