### PR TITLE
fix(1961): Remove request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "lodash": "^4.17.21",
     "node-gyp": "^7.1.2",
     "randomstring": "^1.2.1",
-    "request": "^2.88.0",
-    "requestretry": "^4.0.0",
     "screwdriver-executor-base": "^8.4.0",
     "screwdriver-logger": "^1.1.0",
     "screwdriver-request": "^1.0.2",


### PR DESCRIPTION
## Context

Request package is deprecated.

## Objective

This PR removes the unused request package from the package.json.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
