### PR TITLE
fix(1961): Add extra logs for debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,10 +169,16 @@ class K8sExecutor extends Executor {
     _k8sCommand(options, callback) {
         return request(options)
             .then(function cb() {
+                logger.info(`_k8sCommand success for options: ${JSON.stringify(options)}`);
+
                 // Use "function" (not "arrow function") for getting "arguments"
                 callback(null, ...arguments);
             })
-            .catch(err => callback(err));
+            .catch(err => {
+                logger.debug(`_k8sCommand failing: ${JSON.stringify(err)}`);
+
+                return callback(err);
+            });
     }
 
     /**


### PR DESCRIPTION
## Context

beta.cd is unable to stop or queue builds.

## Objective

Adding logs for debugging purposes.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
