### PR TITLE
feat: remove extra retry logic from getpods fn

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,18 +426,10 @@ class K8sExecutor extends Executor {
             url: `${this.podsUrl}/${podName}/status`,
             method: 'GET',
             headers: { Authorization: `Bearer ${this.token}` },
-            https: { rejectUnauthorized: false },
-            retry: {
-                statusCodes: [200],
-                limit: this.maxAttempts,
-                calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
-            },
-            hooks: {
-                afterResponse: [this.scheduleStatusRetryStrategy]
-            }
+            https: { rejectUnauthorized: false }
         };
 
-        const resp = await this.breaker.runCommand(statusOptions);
+        const resp = await request(statusOptions);
 
         logger.debug(`Build ${buildId} pod response: ${JSON.stringify(resp.body)}`);
         if (resp.statusCode !== 200) {
@@ -737,19 +729,11 @@ class K8sExecutor extends Executor {
             method: 'GET',
             headers: { Authorization: `Bearer ${this.token}` },
             https: { rejectUnauthorized: false },
-            retry: {
-                statusCodes: [200],
-                limit: this.maxAttempts,
-                calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)
-            },
-            hooks: {
-                afterResponse: [this.pendingStatusRetryStrategy]
-            },
             searchParams: {
                 labelSelector: `sdbuild=${this.prefix}${buildId}`
             }
         };
-        const resp = await this.breaker.runCommand(statusOptions); // list of pods
+        const resp = await request(statusOptions); // list of pods
 
         logger.debug(`Build ${buildId} pod response: ${JSON.stringify(resp.body)}`);
         if (resp.statusCode !== 200) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -408,11 +408,7 @@ describe('index', function() {
                 headers: {
                     Authorization: 'Bearer api_key'
                 },
-                https: { rejectUnauthorized: false },
-                retry: {
-                    limit: MAXATTEMPTS
-                },
-                hooks: {}
+                https: { rejectUnauthorized: false }
             };
             putConfig = {
                 url: `${testApiUri}/v4/builds/${testBuildId}`,
@@ -644,7 +640,6 @@ describe('index', function() {
 
             executor = new Executor(options);
             postConfig.json.metadata.annotations = testAnnotations.annotations;
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -673,7 +668,6 @@ describe('index', function() {
 
             executor = new Executor(options);
             postConfig.json.spec = _.assign({}, postConfig.json.spec, testLifecycleHooksSpec);
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -690,7 +684,6 @@ describe('index', function() {
 
             executor = new Executor(options);
             postConfig.json.metadata.labels = testLabels;
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -707,7 +700,6 @@ describe('index', function() {
 
             executor = new Executor(options);
             postConfig.json.spec = _.assign({}, postConfig.json.spec, testSpec);
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -724,7 +716,6 @@ describe('index', function() {
 
             executor = new Executor(options);
             postConfig.json.spec = _.assign({}, postConfig.json.spec, testPreferredSpec);
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -743,7 +734,6 @@ describe('index', function() {
 
             executor = new Executor(options);
             postConfig.json.spec = _.assign({}, postConfig.json.spec, spec);
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
 
             return executor.start(fakeStartConfig).then(() => {
                 assert.calledWith(requestRetryMock.firstCall, postConfig);
@@ -980,23 +970,6 @@ describe('index', function() {
             );
         });
 
-        it('sets retryDelay and maxAttempts', () => {
-            const options = _.assign({}, executorOptions, {
-                requestretry: {
-                    maxAttempts: 1,
-                    retryDelay: 1000
-                }
-            });
-
-            executor = new Executor(options);
-            getConfig.retry.limit = 1;
-            getConfig.hooks = { afterResponse: [executor.scheduleStatusRetryStrategy] };
-
-            return executor.start(fakeStartConfig).then(() => {
-                assert.calledWith(requestRetryMock.firstCall, postConfig);
-                assert.calledWith(requestRetryMock.secondCall, sinon.match(getConfig));
-            });
-        });
     });
 
     describe('periodic', () => {
@@ -1135,8 +1108,6 @@ describe('index', function() {
                     Authorization: 'Bearer api_key'
                 },
                 https: { rejectUnauthorized: false },
-                hooks: { afterResponse: [executor.pendingStatusRetryStrategy] },
-                retry: { limit: MAXATTEMPTS },
                 searchParams: {
                     labelSelector: `sdbuild=beta_${testBuildId}`
                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -969,7 +969,6 @@ describe('index', function() {
                 }
             );
         });
-
     });
 
     describe('periodic', () => {


### PR DESCRIPTION
## Context

Verify function has additional retry logic and breaker fn which is not needed as we have the retry queue

## Objective

verify function is called for messages in the retry-queue which already has a retry mechanism built into it, so we don't need this extra call that overwhelms the k8s api.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
