### PR TITLE
feat(#1658): Make habitat installation configurable

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -27,7 +27,7 @@ spec:
         memory: {{memory}}Gi
     env:
       - name: SD_HAB_ENABLED
-        value: {{sd_hab_enabled}}
+        value: "{{sd_hab_enabled}}"
       - name: SD_RUNTIME_CLASS
         value: {{runtimeClass}}
       - name: SD_PUSHGATEWAY_URL

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -26,6 +26,8 @@ spec:
         cpu: {{cpu}}m
         memory: {{memory}}Gi
     env:
+      - name: SD_HAB_ENABLED
+        value: {{sd_hab_enabled}}
       - name: SD_RUNTIME_CLASS
         value: {{runtimeClass}}
       - name: SD_PUSHGATEWAY_URL

--- a/index.js
+++ b/index.js
@@ -231,6 +231,7 @@ class K8sExecutor extends Executor {
      * @param  {String}  [options.ecosystem.cache.max_go_threads=10000]          Value for build cache max go threads; used only when cache.strategy is disk
      * @param  {Object}  [options.kubernetes.buildSecrets]                       Object representing secrets (e.g.: [ { "secret_env": "SSHCA", "secret_name": "sd-secret", "secret_key", "private" } ] )
      * @param  {Object}  [options.kubernetes.buildSecretsFile]                   Object representing secrets (e.g.: [ { "name": "kvm", "mountPath": "/dev/kvm", "secretName": "sd-secret", "readOnly": true } ] )
+     * @param  {Object}  [options.sdHabEnabled]                                  Value for enabling habitat binary installation in launcher - 'true' / 'false'; Default value is 'true' if not specified;
      */
     constructor(options = {}) {
         super();
@@ -292,7 +293,7 @@ class K8sExecutor extends Executor {
         this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });
         this.secrets = hoek.reach(options, 'kubernetes.buildSecrets', { default: {} });
         this.secretsFile = hoek.reach(options, 'kubernetes.buildSecretsFile', { default: {} });
-        this.sdHabEnabled = options.sdHabEnabled || 'yes';
+        this.sdHabEnabled = options.sdHabEnabled || 'true';
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -292,6 +292,7 @@ class K8sExecutor extends Executor {
         this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });
         this.secrets = hoek.reach(options, 'kubernetes.buildSecrets', { default: {} });
         this.secretsFile = hoek.reach(options, 'kubernetes.buildSecretsFile', { default: {} });
+        this.sdHabEnabled = options.sdHabEnabled || "yes";
     }
 
     /**
@@ -580,7 +581,8 @@ class K8sExecutor extends Executor {
             secret_file_entity: {
                 disabled: secretsFileDisabled,
                 secrets: this.secretsFile
-            }
+            },
+            sd_hab_enabled: this.sdHabEnabled
         });
         const podConfig = yaml.safeLoad(podTemplate);
         const nodeSelectors = {};

--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ class K8sExecutor extends Executor {
         this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });
         this.secrets = hoek.reach(options, 'kubernetes.buildSecrets', { default: {} });
         this.secretsFile = hoek.reach(options, 'kubernetes.buildSecretsFile', { default: {} });
-        this.sdHabEnabled = options.sdHabEnabled || "yes";
+        this.sdHabEnabled = options.sdHabEnabled || 'yes';
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "engines": {
     "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/executor-k8s.git"
+    "url": "git+https://github.com/screwdriver-cd/executor-k8s.git"
   },
   "homepage": "https://github.com/screwdriver-cd/executor-k8s",
   "bugs": "https://github.com/screwdriver-cd/executor-k8s/issues",
@@ -33,10 +32,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -312,7 +312,9 @@ describe('index', function() {
         it('calls breaker with correct config', () =>
             executor
                 .stop({
-                    buildId: testBuildId
+                    buildId: testBuildId,
+                    apiUri: testApiUri,
+                    jobName: 'main'
                 })
                 .then(() => {
                     assert.calledWith(requestRetryMock, deleteConfig);
@@ -326,7 +328,9 @@ describe('index', function() {
 
             return executor
                 .stop({
-                    buildId: testBuildId
+                    buildId: testBuildId,
+                    apiUri: testApiUri,
+                    jobName: 'main'
                 })
                 .then(
                     () => {
@@ -353,7 +357,9 @@ describe('index', function() {
 
             return executor
                 .stop({
-                    buildId: testBuildId
+                    buildId: testBuildId,
+                    apiUri: testApiUri,
+                    jobName: 'main'
                 })
                 .then(
                     () => {


### PR DESCRIPTION
## Context

Habitat installation needs to be optional for the launcher

## Objective

This PR adds the flag `SD_HAB_ENABLED` to executors

## References

https://github.com/screwdriver-cd/launcher/pull/429

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
