### PR TITLE
feat: Add resource limit values to environment variable [1]

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -48,6 +48,16 @@ spec:
         value: "/sd/commands/"
       - name: SD_TEMP
         value: "/opt/sd_tmp"
+      - name: CONTAINER_CPU_LIMIT
+        valueFrom:
+          resourceFieldRef:
+            containerName: {{build_id_with_prefix}}
+            resource: limits.cpu
+      - name: CONTAINER_MEMORY_LIMIT
+        valueFrom:
+          resourceFieldRef:
+            containerName: {{build_id_with_prefix}}
+            resource: limits.memory
     {{#if docker.enabled}}
       - name: SD_DIND_SHARE_PATH
         value: "/opt/sd_dind_share"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Allow the value set as resource limit in the build pod to be referenced as an environment variable at build time.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add two environment variables to the build pod template.
- CONTAINER_CPU_LIMIT
- CONTAINER_MEMORY_LIMIT

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
