### PR TITLE
fix: Environment variable for referencing resources allocated to the build pod

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -51,12 +51,12 @@ spec:
       - name: CONTAINER_CPU_LIMIT
         valueFrom:
           resourceFieldRef:
-            containerName: {{build_id_with_prefix}}
+            containerName: "{{build_id_with_prefix}}"
             resource: limits.cpu
       - name: CONTAINER_MEMORY_LIMIT
         valueFrom:
           resourceFieldRef:
-            containerName: {{build_id_with_prefix}}
+            containerName: "{{build_id_with_prefix}}"
             resource: limits.memory
     {{#if docker.enabled}}
       - name: SD_DIND_SHARE_PATH


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Follow-up of  https://github.com/screwdriver-cd/executor-k8s/pull/179.
ContainerName is not enclosed in double quotes, so it is not handled as string and an error occurs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Enclose containerName in double quotes to handle it as string.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
