### PR TITLE
fix: Do not retry when statusCode 4XX

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,6 +314,8 @@ class K8sExecutor extends Executor {
             url: `${apiUri}/v4/builds/${buildId}`,
             headers: { Authorization: `Bearer ${token}` },
             https: { rejectUnauthorized: false },
+            // Do not retry when there is a 4XX error
+            shouldRetry: err => err && err.statusCode && !(err.statusCode >= 400 && err.statusCode < 500),
             retry: {
                 limit: this.maxAttempts,
                 calculateDelay: ({ computedValue }) => (computedValue ? this.retryDelay : 0)


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When calling API for updateBuild, it should not retry if a response has 4XX status code.
It is taking longer to fail because of this retry.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add retry option not to retry when a response has 4XX status code.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
