### PR TITLE
[2] fix(2882): drop k8s hostname from build stats data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const Executor = require('screwdriver-executor-base');
 const Fusebox = require('circuit-fuses').breaker;
-const fs = require('fs');
 const hoek = require('@hapi/hoek');
-const path = require('path');
 const randomstring = require('randomstring');
 const request = require('screwdriver-request');
 const handlebars = require('handlebars');
@@ -372,15 +372,13 @@ class K8sExecutor extends Executor {
             const updateConfig = {
                 apiUri: this.ecosystem.api,
                 buildId,
-                token
+                token,
+                stats: {
+                    imagePullStartTime: new Date().toISOString()
+                }
             };
 
-            if (nodeName) {
-                updateConfig.stats = {
-                    hostname: nodeName,
-                    imagePullStartTime: new Date().toISOString()
-                };
-            } else {
+            if (!nodeName) {
                 updateConfig.statusMessage = 'Waiting for resources to be available.';
             }
             await this.updateBuild(updateConfig);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -474,7 +474,7 @@ describe('index', function () {
             });
         });
 
-        it('successfully calls start and update hostname and imagePullStartTime', () => {
+        it('successfully calls start and update imagePullStartTime', () => {
             const dateNow = Date.now();
             const isoTime = new Date(dateNow).toISOString();
             const clock = sinon.useFakeTimers({
@@ -483,7 +483,6 @@ describe('index', function () {
             });
 
             putConfig.json.stats = {
-                hostname: 'node1.my.k8s.cluster.com',
                 imagePullStartTime: isoTime
             };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

k8s hostname will be set from launcher by https://github.com/screwdriver-cd/launcher/pull/457 .
So we does not need to set hostname in executor-k8s.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Drop k8s hostname from build stats data when `executor.start` call.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2882

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
