### PR TITLE
fix: Add pipelineName, jobName, prNum, and template info to pod labels [2]

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -2,8 +2,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
+    {{#if pipeline_name}}
     screwdriver.cd/pipeline: "{{pipeline_name}}"
+    {{/if}}
+    {{#if job_name}}
     screwdriver.cd/job: "{{job_name}}"
+    {{/if}}
     {{#if template_full_name}}
     screwdriver.cd/template_name: "{{template_full_name}}"
     {{/if}}

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -1,22 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  labels:
-    {{#if pipeline_name}}
-    screwdriver.cd/pipeline: "{{pipeline_name}}"
-    {{/if}}
-    {{#if job_name}}
-    screwdriver.cd/job: "{{job_name}}"
-    {{/if}}
-    {{#if template_full_name}}
-    screwdriver.cd/template_name: "{{template_full_name}}"
-    {{/if}}
-    {{#if template_version}}
-    screwdriver.cd/template_version: "{{template_version}}"
-    {{/if}}
-    {{#if pr_number}}
-    screwdriver.cd/pr_number: "{{pr_number}}"
-    {{/if}}
   name: "{{pod_name}}"
 spec:
   {{#if runtimeClass}}

--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -1,6 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  labels:
+    screwdriver.cd/pipeline: "{{pipeline_name}}"
+    screwdriver.cd/job: "{{job_name}}"
+    {{#if template_full_name}}
+    screwdriver.cd/template_name: "{{template_full_name}}"
+    {{/if}}
+    {{#if template_version}}
+    screwdriver.cd/template_version: "{{template_version}}"
+    {{/if}}
+    {{#if pr_number}}
+    screwdriver.cd/pr_number: "{{pr_number}}"
+    {{/if}}
   name: "{{pod_name}}"
 spec:
   {{#if runtimeClass}}

--- a/index.js
+++ b/index.js
@@ -445,10 +445,13 @@ class K8sExecutor extends Executor {
      * @return {Object}   podConfig the pod config object
      */
     createPodConfig(config) {
-        const { buildId, eventId, container, token } = config;
+        const { buildId, eventId, container, token, prNum } = config;
         let jobId = hoek.reach(config, 'jobId', { default: '' });
         const pipelineId = hoek.reach(config, 'pipeline.id', { default: '' });
+        const pipelineName = hoek.reach(config, 'pipeline.name', { default: '' });
         const jobName = hoek.reach(config, 'jobName', { default: '' });
+        const templateFullName = hoek.reach(config, 'template.fullName', { default: '' });
+        const templateVersion = hoek.reach(config, 'template.version', { default: '' });
         const annotations = this.parseAnnotations(hoek.reach(config, 'annotations', { default: {} }));
 
         const cpuValues = {
@@ -542,8 +545,13 @@ class K8sExecutor extends Executor {
             prefix: this.prefix,
             build_id: buildId,
             job_id: jobId,
+            job_name: jobName,
+            pr_number: prNum,
             pipeline_id: pipelineId,
+            pipeline_name: pipelineName,
             event_id: eventId,
+            template_full_name: templateFullName,
+            template_version: templateVersion,
             build_timeout: buildTimeout,
             container,
             api_uri: this.ecosystem.api,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -134,7 +134,9 @@ describe('index', function () {
         testEnv: true,
         app: 'screwdriver',
         sdbuild: 'beta_15',
-        tier: 'builds'
+        tier: 'builds',
+        'screwdriver.cd/job': 'main',
+        'screwdriver.cd/pipeline': 'd2lam/test'
     };
     let executorOptions;
 
@@ -395,7 +397,13 @@ describe('index', function () {
                         dnsPolicy: 'ClusterFirst',
                         imagePullPolicy: 'Always',
                         memory: 2,
-                        labels: { app: 'screwdriver', sdbuild: 'beta_15', tier: 'builds' }
+                        labels: {
+                            app: 'screwdriver',
+                            sdbuild: 'beta_15',
+                            tier: 'builds',
+                            'screwdriver.cd/job': 'main',
+                            'screwdriver.cd/pipeline': 'd2lam/test'
+                        }
                     },
                     spec: {
                         containers: [{ name: 'beta_15' }],
@@ -433,7 +441,14 @@ describe('index', function () {
                 buildId: testBuildId,
                 container: testContainer,
                 token: testToken,
-                apiUri: testApiUri
+                apiUri: testApiUri,
+                jobName: 'main',
+                pipeline: {
+                    id: 12345,
+                    name: 'd2lam/test',
+                    scmContext: 'github:github.com',
+                    configPipelineId: null
+                }
             };
             fakePutResponse = {
                 id: testBuildId


### PR DESCRIPTION
## Context

Pods might need more information.

## Objective

This PR adds pipelineName, jobName, prNum, and template info to pod labels.

## References

Blocked by https://github.com/screwdriver-cd/models/pull/592

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
