### PR TITLE
fix: pod label value is <= 63 in length

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function setLabels(podConfig, podLabels, config) {
             ..._.toString(label)
                 .replaceAll(DISALLOWED_LABEL_CHAR_REGEX_PATTERN, '.')
                 .matchAll(MATCH_LABEL_REGEX_PATTERN)
-        ][0][1];
+        ][0][1].slice(0, 63);
     };
 
     const { buildContainerName, jobName, templateFullName, templateVersion, pipelineName, prNum, cpu, memory, disk } =


### PR DESCRIPTION
refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
