### PR TITLE
fix: for mv -f during launcher setup

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -147,9 +147,9 @@ spec:
   - name: "launcher-{{build_id_with_prefix}}"
     image: {{launcher_image}}
     {{#if cache.diskEnabled}}
-    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/. $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
+    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && chmod -R 777 /opt/sdpipelinecache && chmod -R 777 /opt/sdjobcache && chmod -R 777 /opt/sdeventcache && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/. $TEMP_DIR/hab && mv -f $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
     {{else}}
-    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/. $TEMP_DIR/hab && mv $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
+    command: ['/bin/sh', '-c', 'echo launcher_start_ts:`date "+%s"` > /workspace/metrics && if ! [ -f /opt/launcher/launch ]; then TEMP_DIR=`mktemp -d -p /opt/launcher` && cp -a /opt/sd/* $TEMP_DIR && mkdir -p $TEMP_DIR/hab && cp -a /hab/. $TEMP_DIR/hab && mv -f $TEMP_DIR/* /opt/launcher && rm -rf $TEMP_DIR || true; else ls /opt/launcher; fi; echo launcher_end_ts:`date "+%s"` >> /workspace/metrics']
     {{/if}}
     volumeMounts:
     - mountPath: /opt/launcher


### PR DESCRIPTION
## Context

If multiple builds which are getting scheduled in a node are trying to perform launcher upgrade, them mv can hang.

```
/opt/screwdriver/sdlauncher/v6.0.174 $ ls -al tmp.*
tmp.bJNieJ/ tmp.IdlIfa/ tmp.nhNfCN/
/opt/screwdriver/sdlauncher/v6.0.174/tmp.bJNieJ $ mv bin/ ../
mv: overwrite ‘../bin’? ^C
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
