### PR TITLE
fix(3089): restore k8s hostname into build stats data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
 const Executor = require('screwdriver-executor-base');
 const Fusebox = require('circuit-fuses').breaker;
+const fs = require('fs');
 const hoek = require('@hapi/hoek');
+const path = require('path');
 const randomstring = require('randomstring');
 const request = require('screwdriver-request');
 const handlebars = require('handlebars');
@@ -427,13 +427,15 @@ class K8sExecutor extends Executor {
             const updateConfig = {
                 apiUri: this.ecosystem.api,
                 buildId,
-                token,
-                stats: {
-                    imagePullStartTime: new Date().toISOString()
-                }
+                token
             };
 
-            if (!nodeName) {
+            if (nodeName) {
+                updateConfig.stats = {
+                    hostname: nodeName,
+                    imagePullStartTime: new Date().toISOString()
+                };
+            } else {
                 updateConfig.statusMessage = 'Waiting for resources to be available.';
             }
             await this.updateBuild(updateConfig);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -506,7 +506,7 @@ describe('index', function () {
             });
         });
 
-        it('successfully calls start and update imagePullStartTime', () => {
+        it('successfully calls start and update hostname and imagePullStartTime', () => {
             const dateNow = Date.now();
             const isoTime = new Date(dateNow).toISOString();
             const clock = sinon.useFakeTimers({
@@ -515,6 +515,7 @@ describe('index', function () {
             });
 
             putConfig.json.stats = {
+                hostname: 'node1.my.k8s.cluster.com',
                 imagePullStartTime: isoTime
             };
 


### PR DESCRIPTION
## Context

Reverts screwdriver-cd/executor-k8s#186

## Objective

If the launcher fails during the initialization container setup, [the node information for the build execution](https://github.com/sonic-screwdriver-cd/launcher/blob/5f9a44855bfc31b1bb4b947e408ca318a6f8e2c9/screwdriver/screwdriver.go#L446-L451) will not be updated. Rolling back this commit should enable the executor to update the node that the build is scheduled to run on, while still allowing the launcher to update the information afterward. If the hostname remains unchanged, the action should be idempotent regardless.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3089

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
