### PR TITLE
fix(3089): add build node name update in the _verify which is used in retry queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const yaml = require('js-yaml');
 const _ = require('lodash');
 const jwt = require('jsonwebtoken');
 const logger = require('screwdriver-logger');
-const { hostname } = require('os');
 
 const DEFAULT_BUILD_TIMEOUT = 90; // 90 minutes
 const MAX_BUILD_TIMEOUT = 120; // 120 minutes
@@ -730,13 +729,13 @@ class K8sExecutor extends Executor {
         let message;
         let waitingReason;
 
-        pods.find(async (p) =>{
+        pods.find(async p => {
             const status = hoek.reach(p, 'status.phase').toLowerCase();
             const nodeName = hoek.reach(p, 'spec.nodeName');
             const podStartTime = hoek.reach(p, 'status.startTime');
 
             // update the hostname in the build stats if nodeName is available
-            // nodeName is not available for pending pods 
+            // nodeName is not available for pending pods
             if (nodeName) {
                 const updateConfig = {
                     apiUri: this.ecosystem.api,
@@ -747,9 +746,10 @@ class K8sExecutor extends Executor {
                         imagePullStartTime: new Date(podStartTime).toISOString()
                     }
                 };
+
                 await this.updateBuild(updateConfig);
             }
-            
+
             waitingReason = hoek.reach(p, CONTAINER_WAITING_REASON_PATH);
 
             if (status === 'failed' || status === 'unknown') {

--- a/index.js
+++ b/index.js
@@ -735,7 +735,7 @@ class K8sExecutor extends Executor {
             const status = hoek.reach(p, 'status.phase').toLowerCase();
 
             nodeName = hoek.reach(p, 'spec.nodeName');
-            // podStartTime = hoek.reach(p, 'status.startTime');
+            podStartTime = hoek.reach(p, 'status.startTime');
 
             waitingReason = hoek.reach(p, CONTAINER_WAITING_REASON_PATH);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1197,7 +1197,7 @@ describe('index', function () {
         });
         it('gets all pods for given buildid', async () => {
             await executor.verify(fakeVerifyConfig);
-            assert.calledOnce(requestRetryMock);
+            assert.equal(requestRetryMock.callCount, 2);
             assert.calledWith(requestRetryMock, sinon.match(getPodsConfig));
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1180,7 +1180,8 @@ describe('index', function () {
                     items: [
                         {
                             status: {
-                                phase: 'pending'
+                                phase: 'pending',
+                                startTime: '2024-05-02T18:51:54Z'
                             },
                             spec: {
                                 nodeName: 'node1.my.k8s.cluster.com'
@@ -1204,6 +1205,7 @@ describe('index', function () {
             const pod = {
                 status: {
                     phase: 'pending',
+                    startTime: '2024-05-02T18:51:54Z',
                     containerStatuses: [
                         {
                             state: {


### PR DESCRIPTION
## Context

When a pod faces resource constraints and enters a pending state, it's placed in a retry queue. In the underlying process, the retry queue invokes the _verify method within the executor implementation, as specified in [this approach](https://github.com/screwdriver-cd/buildcluster-queue-worker/blob/c6086f39ca196f89ecd38d46eb48f344eb8adf14/receiver.js#L110-L113). Currently, the retry mechanism lacks the capability to update information regarding the build node.

## Objective

Updating the build node information proactively in the retry queue, to enhance efficiency and reduce the likelihood of missing it in the data store.  

## References

https://github.com/screwdriver-cd/screwdriver/issues/3089

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
