### PR TITLE
feat(3359): Add buildkitd annotaions

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -128,7 +128,11 @@ spec:
   {{/unless}}
   {{#if docker.enabled}}
   - name: dind
+    {{#if rootlessbuildkit.enabled}}
+    image: docker:20.10-dind-rootless
+    {{#else}}
     image: docker:20.10-dind
+    {{/if}}
     resources:
       limits:
         cpu: {{docker.cpu }}m
@@ -142,6 +146,27 @@ spec:
         mountPath: /opt/sd_dind_share
       - name: dind-client-certs
         mountPath: /certs/client
+  {{/if}}
+  {{#if rootlessbuildkit.enabled}}
+  - name: buildkitd
+    # TODO: need to push image
+    image: screwdrivercd/buildkit-rootless:xxx
+    resources:
+      limits:
+        cpu: {{buildkit.cpu}}m
+        memory: {{buildkit.memory}}Gi
+    args:
+      - --addr
+      - tcp://localhost:1234
+      - --config
+      - /etc/buildkit/buildkitd.toml
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: buildkit-client-certs
+      mountPath: /certs/buildkit/client
+    - name: buildkit-server-certs
+      mountPath: /certs/buildkit/server
   {{/if}}
   initContainers:
   - name: "launcher-{{build_id_with_prefix}}"
@@ -190,6 +215,12 @@ spec:
     - name: dind-share
       emptyDir: {}
     - name: dind-client-certs
+      emptyDir: {}
+    {{/if}}
+    {{#if rootlessbuildkit.enabled}}
+    - name: buildkit-client-certs
+      emptyDir: {}
+    - name: buildkit-server-certs
       emptyDir: {}
     {{/if}}
     {{#if cache.diskEnabled}}

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ const DISK_CACHE_STRATEGY = 'disk';
 const DOCKER_ENABLED_KEY = 'dockerEnabled';
 const DOCKER_MEMORY_RESOURCE = 'dockerRam';
 const DOCKER_CPU_RESOURCE = 'dockerCpu';
+const ROOTLESS_BUILDKIT_ENABLED_KEY = 'rootlessBuildkitEnabled';
+const BUILDKIT_MEMORY_RESOURCE = 'buildkitRam';
+const BUILDKIT_CPU_RESOURCE = 'buildkitCpu';
 const ANNOTATIONS_PATH = 'metadata.annotations';
 const LABELS_PATH = 'metadata.labels';
 const CONTAINER_WAITING_REASON_PATH = 'status.containerStatuses.0.state.waiting.reason';
@@ -555,6 +558,7 @@ class K8sExecutor extends Executor {
             memory = Math.min(memConfig, this.maxMemory);
         }
 
+        // for dind container
         const dockerEnabledConfig = annotations[DOCKER_ENABLED_KEY];
         const DOCKER_ENABLED = this.dockerFeatureEnabled && dockerEnabledConfig === true;
 
@@ -563,6 +567,16 @@ class K8sExecutor extends Executor {
 
         const dockerMemoryConfig = annotations[DOCKER_MEMORY_RESOURCE];
         const DOCKER_RAM = dockerMemoryConfig in memValues ? memValues[dockerMemoryConfig] : memValues.LOW;
+
+        // for buildkit container
+        const rootlessBuildkitEnabledConfig = annotations[ROOTLESS_BUILDKIT_ENABLED_KEY];
+        const ROOTLESS_BUILDKIT_ENABLED = this.rootlessBuildkitFeatureEnabled && rootlessBuildkitEnabledConfig === true;
+
+        const buildkitCpuConfig = annotations[BUILDKIT_CPU_RESOURCE];
+        const BUILDKIT_CPU = buildkitCpuConfig in cpuValues ? cpuValues[buildkitCpuConfig] * 1000 : cpuValues.LOW * 1000;
+
+        const buildkitMemoryConfig = annotations[BUILDKIT_MEMORY_RESOURCE];
+        const BUILDKIT_RAM = buildkitMemoryConfig in memValues ? memValues[buildkitMemoryConfig] : memValues.LOW;
 
         const random = randomstring.generate({
             length: 5,
@@ -634,6 +648,11 @@ class K8sExecutor extends Executor {
                 enabled: DOCKER_ENABLED,
                 cpu: DOCKER_CPU,
                 memory: DOCKER_RAM
+            },
+            rootlessbuildkit: {
+                enabled: ROOTLESS_BUILDKIT_ENABLED,
+                cpu: BUILDKIT_CPU,
+                memory: BUILDKIT_RAM
             },
             dns_policy: this.dnsPolicy,
             image_pull_policy: this.imagePullPolicy,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We want to use BuildKit in rootless mode to make builds more secure.  
For more details, please refer to the issue.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When a user sets `rootlessBuildkitEnabled` in the annotations during a build, a BuildKit container will be started as a sidecar.  
It also allows specifying the CPU and memory resources for the BuildKit sidecar.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3359

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
