### PR TITLE
feat(3359): Fix lint

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,7 +347,9 @@ class K8sExecutor extends Executor {
         this.cacheMaxSizeInMB = hoek.reach(options, 'ecosystem.cache.max_size_mb', { default: 0 });
         this.cacheMaxGoThreads = hoek.reach(options, 'ecosystem.cache.max_go_threads', { default: 10000 });
         this.dockerFeatureEnabled = hoek.reach(options, 'kubernetes.dockerFeatureEnabled', { default: false });
-        this.rootlessBuildkitFeatureEnabled = hoek.reach(options, 'kubernetes.rootlessBuildkitFeatureEnabled', { default: false });
+        this.rootlessBuildkitFeatureEnabled = hoek.reach(options, 'kubernetes.rootlessBuildkitFeatureEnabled', {
+            default: false
+        });
         this.annotations = hoek.reach(options, 'kubernetes.annotations');
         this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });
         this.secrets = hoek.reach(options, 'kubernetes.buildSecrets', { default: {} });
@@ -574,7 +576,8 @@ class K8sExecutor extends Executor {
         const ROOTLESS_BUILDKIT_ENABLED = this.rootlessBuildkitFeatureEnabled && rootlessBuildkitEnabledConfig === true;
 
         const buildkitCpuConfig = annotations[BUILDKIT_CPU_RESOURCE];
-        const BUILDKIT_CPU = buildkitCpuConfig in cpuValues ? cpuValues[buildkitCpuConfig] * 1000 : cpuValues.LOW * 1000;
+        const BUILDKIT_CPU =
+            buildkitCpuConfig in cpuValues ? cpuValues[buildkitCpuConfig] * 1000 : cpuValues.LOW * 1000;
 
         const buildkitMemoryConfig = annotations[BUILDKIT_MEMORY_RESOURCE];
         const BUILDKIT_RAM = buildkitMemoryConfig in memValues ? memValues[buildkitMemoryConfig] : memValues.LOW;


### PR DESCRIPTION
## Context
In the [previous PR](https://github.com/screwdriver-cd/executor-k8s/pull/204), a lint error was found in the unit tests.
https://cd.screwdriver.cd/pipelines/28/builds/976493/steps/test

## Objective
Fix lint Error

```bash
> screwdriver-executor-k8s@17.0.0 pretest
> eslint .


/Users/tminegis/work/src/github.com/sonic-screwdriver-cd/executor-k8s/index.js
  294:16  warning  Constructor has too many statements (57). Maximum allowed is 50               max-statements
  294:16  warning  Constructor has a complexity of 23. Maximum allowed is 20                     complexity
  510:5   warning  Method 'createPodConfig' has too many lines (188). Maximum allowed is 150     max-lines-per-function
  510:20  warning  Method 'createPodConfig' has too many statements (66). Maximum allowed is 50  max-statements
  510:20  warning  Method 'createPodConfig' has a complexity of 24. Maximum allowed is 20        complexity

/Users/tminegis/work/src/github.com/sonic-screwdriver-cd/executor-k8s/test/index.test.js
    36:19  warning  Function has too many lines (1485). Maximum allowed is 150             max-lines-per-function
   383:23  warning  Arrow function has too many lines (653). Maximum allowed is 150        max-lines-per-function
  1153:24  warning  Async arrow function has too many lines (373). Maximum allowed is 150  max-lines-per-function

✖ 8 problems (0 errors, 8 warnings)
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
