### PR TITLE
fix(3359): Fixed pod settings for buildkitd container

### DIFF
--- a/config/pod.yaml.hbs
+++ b/config/pod.yaml.hbs
@@ -104,6 +104,12 @@ spec:
     - name: dind-client-certs
       mountPath: /certs/client
     {{/if}}
+    {{#if rootlessbuildkit.enabled}}
+    - name: buildkit-client-certs
+      mountPath: /certs/buildkit/client
+    - name: buildkit-server-certs
+      mountPath: /certs/buildkit/server
+    {{/if}}
     {{#if cache.diskEnabled}}
     - mountPath: /sdpipelinecache
       name: sd-pipeline-cache
@@ -153,8 +159,8 @@ spec:
     image: screwdrivercd/buildkit-rootless:xxx
     resources:
       limits:
-        cpu: {{buildkit.cpu}}m
-        memory: {{buildkit.memory}}Gi
+        cpu: {{rootlessbuildkit.cpu}}m
+        memory: {{rootlessbuildkit.memory}}Gi
     args:
       - --addr
       - tcp://localhost:1234

--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ class K8sExecutor extends Executor {
         this.cacheMaxGoThreads = hoek.reach(options, 'ecosystem.cache.max_go_threads', { default: 10000 });
         this.dockerFeatureEnabled = hoek.reach(options, 'kubernetes.dockerFeatureEnabled', { default: false });
         this.rootlessBuildkitFeatureEnabled = hoek.reach(options, 'kubernetes.rootlessBuildkitFeatureEnabled', {
-            default: false
+            default: true
         });
         this.annotations = hoek.reach(options, 'kubernetes.annotations');
         this.privileged = hoek.reach(options, 'kubernetes.privileged', { default: false });


### PR DESCRIPTION
## Context
Fixed several configuration issues that existed in the [previous PR](https://github.com/screwdriver-cd/executor-k8s/pull/204).

- Add volumeMounts for buildkitd
- Fix the variable name for buildkit CPU/memory resource limits
- Set the rootlessBuildkitFeatureEnabled flag to true

## References
Issue: https://github.com/screwdriver-cd/screwdriver/issues/3359
- executor-k8s pr (this pr): https://github.com/screwdriver-cd/executor-k8s/pull/204

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
