### PR TITLE
fix: remove unused node-gyp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "node-gyp": "^11.1.0",
     "randomstring": "^1.3.1",
     "screwdriver-executor-base": "^11.1.0",
     "screwdriver-logger": "^3.0.0",


### PR DESCRIPTION
## Context

Snyk reported a high severity vulnerability in `brace-expansion` through the `node-gyp` dependency chain in `screwdriver-executor-k8s`.

While investigating, `node-gyp` looked unused in this repository.

## Objective

This PR removes `node-gyp` from the direct dependencies of `screwdriver-executor-k8s` to eliminate that vulnerable path.

`node-gyp` did not appear to be used by the current code, scripts, or tests. If there is a known reason this dependency is still needed, please share it.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
