### PR TITLE
fix: upgrade js-yaml to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@hapi/hoek": "^11.0.7",
     "circuit-fuses": "^6.0.0",
     "handlebars": "^4.7.8",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^5.2.3",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "randomstring": "^1.3.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const mockery = require('mockery');
 const yaml = require('js-yaml');
+const handlebars = require('handlebars');
 const rewire = require('rewire');
 const index = rewire('../index.js');
 const _ = require('lodash');
@@ -29,6 +30,8 @@ spec:
 command:
 - "/opt/sd/launch {{api_uri}} {{store_uri}} {{token}} {{build_timeout}} {{build_id}}"
 `;
+
+const loadTestTimYaml = () => yaml.load(handlebars.compile(TEST_TIM_YAML)({}));
 
 const SMALLEST_FLOAT64 = 2.2250738585072014e-308;
 
@@ -880,7 +883,7 @@ describe('index', function () {
 
         beforeEach(() => {
             nodeSelectors = null;
-            fakeConfig = yaml.load(TEST_TIM_YAML);
+            fakeConfig = loadTestTimYaml();
         });
 
         it('does nothing if nodeSelector is not set', () => {
@@ -910,7 +913,7 @@ describe('index', function () {
 
         beforeEach(() => {
             nodeSelectors = null;
-            fakeConfig = yaml.load(TEST_TIM_YAML);
+            fakeConfig = loadTestTimYaml();
         });
 
         it('does nothing if preferredNodeSelector is not set', () => {
@@ -952,7 +955,7 @@ describe('index', function () {
                     }
                 }
             };
-            fakeConfig = yaml.load(TEST_TIM_YAML);
+            fakeConfig = loadTestTimYaml();
         });
 
         it('does nothing if no build container is found', () => {


### PR DESCRIPTION
## Context

Snyk detected a vulnerability in js-yaml dependency paths.

## Objective

Upgrade js-yaml to v5.2.3 and update pod template tests for the stricter v5 parser behavior.

## References

- https://github.com/screwdriver-cd/screwdriver/issues/3510
- https://github.com/nodeca/js-yaml/blob/5.2.3/docs/migrate_v4_to_v5.md